### PR TITLE
feat: migrate from ethers.js v6 to viem 2 (Wave 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Notes:
 
 ## Architecture
 
-This is a React SPA that queries Ethereum blockchain balances (ETH and DAI) via ethers.js v6. There is no backend — all blockchain calls happen in the browser against an external JSON-RPC endpoint configured via `VITE_RPCENDPOINT`.
+This is a React SPA that queries Ethereum blockchain balances (ETH and DAI) via viem 2. There is no backend — all blockchain calls happen in the browser against an external JSON-RPC endpoint configured via `VITE_RPCENDPOINT`.
 
 ### Entry Flow
 
@@ -73,7 +73,7 @@ This is a React SPA that queries Ethereum blockchain balances (ETH and DAI) via 
 
 - **Pages** (`src/pages/`): Route-level components (`index/` = home, `about/`)
 - **Components** (`src/components/`): `AccountForm` (blockchain query UI), `Counter` (Redux demo), `Layout` (Header/Footer with MUI drawer nav), `Logo`
-- **Ethereum service** (`src/service/ether/ether.ts`): Uses `ethers.JsonRpcProvider` to query ETH balances and DAI token contract. RPC endpoint comes from `VITE_RPCENDPOINT` env var. DAI contract resolved via ENS name `dai.tokens.ethers.eth`.
+- **Ethereum service** (`src/service/ether/ether.ts`): Uses viem's `createPublicClient` (mainnet, http transport) to query ETH balances and DAI token contract reads. Exposes `getETHBalance(addr)` and `getDAIBalance(addr)` returning typed result objects (`{block, balance}` / `{block, name, symbol, balance, balanceFormatted}`). RPC endpoint comes from `VITE_RPCENDPOINT` env var. DAI contract address hardcoded to canonical mainnet `0x6B17…1d0F` (no ENS lookup). Re-exports `formatEther`, `formatUnits`, `getAddress` so the component layer doesn't import viem directly.
 - **State** (`src/store/`): Redux Toolkit with slices for `counter` (`counterSlice.ts`) and `common` (`commonSlice.ts`). Uses `configureStore`, `createSlice`, and typed hooks (`useAppDispatch`, `useAppSelector`).
 - **i18n** (`src/locale.ts`): i18next with `react-i18next`, static English translations from `src/locales/en.json`
 
@@ -155,7 +155,7 @@ Last reviewed: 2026-04-19 (post `/upgrade-analysis` Wave 1+2+3 applied). Review 
 - [x] ~~**Add `make e2e` target**~~ — done (2026-04-19), KinD + `cloud-provider-kind` (LoadBalancer with real IPs on the kind Docker network — portfolio default) + `e2e/e2e-test.sh` (curl) + `e2e/account-form.spec.ts` (Playwright); CI `e2e` + `dast` jobs gated `if: vars.ACT != 'true'`
 - [x] ~~**Harden image publish pipeline**~~ — done (2026-04-19), Pattern A: build-for-scan (load:true) → Trivy image scan (CRITICAL/HIGH blocking) → smoke test → multi-arch push → cosign keyless OIDC signing by digest. Separate `dast` job (OWASP ZAP baseline) parallel with `docker`. `provenance: false` + `sbom: false` keep GHCR "OS / Arch" tab rendering.
 - [x] ~~**Dockerfile: migrate from `npm install -g pnpm` to corepack**~~ — done (2026-04-19), both Dockerfiles use `corepack enable pnpm`; `packageManager` field in package.json declares `pnpm@10.33.0`
-- [ ] **Wave 4: ethers.js → viem migration** — Re-confirmed 2026-04-19: ethers last commit 2026-02-13 (2+ mo), last release v6.16.0 on 2025-12-03 (4+ mo), 638 open issues, bus factor 1 (`ricmoo`). viem actively released (latest viem@2.48.1 on 2026-04-17), 3446⭐, 34 open issues. Migration scope: rewrite `src/service/ether/ether.ts` against viem's `createPublicClient`/`getBalance`/`formatEther` (eliminates the `Promise.all([assignment-side-effect])` pattern), rewrite both test files at `src/service/ether/__tests__/`. Both libraries are MIT — clean license migration. Effort: ~1 day.
+- [x] ~~**Wave 4: ethers.js → viem migration**~~ — done (2026-04-19). Replaced `ethers.JsonRpcProvider`/`ethers.Contract` with viem's `createPublicClient` + `readContract` (mainnet chain, http transport). DAI ENS lookup (`dai.tokens.ethers.eth`) replaced by hardcoded canonical address `0x6B17…1d0F`. Service API now returns typed result objects instead of mutating module-level `let` exports — eliminates the `Promise.all([assignment-side-effect])` pattern. AccountForm reads from returned values. Tests rewritten: unit mocks `createPublicClient`, integration uses real RPC, AccountForm component test mocks the full module surface. vite.config.ts vendor chunk renamed `vendor-ethers` → `vendor-viem` (~253 KB, comparable size).
 - [ ] **Wave 4: MUI v7 → v9** — `@mui/material` and `@mui/icons-material` are two majors behind (7.3.9 → 9.0.0). Stepwise: v7 → v8 (theme overhaul, `Grid` → `Grid2`), then v8 → v9 (layout breaking changes). Files affected: `src/components/AccountForm.tsx`, `src/components/Layout.tsx`, `src/theme.tsx`. Effort: 1–2 days incl. visual regression checks.
 - [x] ~~**K8s deployment: enable resource requests/limits**~~ — done (2026-04-19), conservative defaults (cpu 10m/200m, mem 32Mi/64Mi) + per-init `5m/100m` and `16Mi/32Mi`.
 - [x] ~~**K8s deployment: add securityContext**~~ — done (2026-04-19), pod-level `runAsNonRoot:true, runAsUser:101, runAsGroup:101, fsGroup:101, seccompProfile:RuntimeDefault`; container-level `readOnlyRootFilesystem:true, allowPrivilegeEscalation:false, capabilities.drop:[ALL]`. Init container `seed-html` copies baked HTML to a writable emptyDir so `start-nginx.sh`'s envsubst can rewrite the bundled JS at startup. `.trivyignore` cleared.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Web3 Sample App
 
-Reference React SPA that queries ETH and DAI ERC-20 balances from the Ethereum blockchain via ethers.js v6, packaged as a non-root nginx container and deployable to Kubernetes.
+Reference React SPA that queries ETH and DAI ERC-20 balances from the Ethereum blockchain via viem, packaged as a non-root nginx container and deployable to Kubernetes.
 
 | Component | Technology |
 |-----------|------------|
@@ -14,7 +14,7 @@ Reference React SPA that queries ETH and DAI ERC-20 balances from the Ethereum b
 | Build tool | Vite 8 (oxc minifier, Rolldown manual chunks) |
 | UI | MUI v7, Tailwind CSS v4 (`@tailwindcss/postcss`) |
 | State | Redux Toolkit 2 (`createSlice`, typed hooks) |
-| Web3 | ethers.js v6 (`JsonRpcProvider`, `Contract`) |
+| Web3 | viem 2 (`createPublicClient`, `http`, `readContract`, `parseAbi`) |
 | i18n | i18next + react-i18next (English bundled) |
 | Testing | Vitest 4, React Testing Library, jsdom |
 | Container | Builder: `node:24.15.0-alpine`; runtime: `nginxinc/nginx-unprivileged:1.29.8-alpine` (port 8080, runs as UID 101) |
@@ -28,9 +28,9 @@ C4Context
     title System Context — Web3 Sample App
 
     Person(user, "End User", "Browser, supplies an Ethereum address")
-    System(spa, "Web3 Sample App", "React 19 SPA, nginx-served, queries balances")
-    System_Ext(rpc, "Ethereum JSON-RPC", "Provider configured via VITE_RPCENDPOINT")
-    System_Ext(dai, "DAI ERC-20 Contract", "dai.tokens.ethers.eth on Ethereum mainnet")
+    System(spa, "Web3 Sample App", "React 19 SPA, viem 2, nginx-served")
+    System_Ext(rpc, "Ethereum JSON-RPC", "viem PublicClient, mainnet, http transport via VITE_RPCENDPOINT")
+    System_Ext(dai, "DAI ERC-20 Contract", "0x6B17…1d0F on Ethereum mainnet")
 
     Rel(user, spa, "Uses", "HTTPS")
     Rel(spa, rpc, "getBalance / getBlockNumber", "JSON-RPC over HTTPS")
@@ -67,7 +67,7 @@ The SPA is a single React app served from a static nginx image. All blockchain c
 
 1. `src/main.tsx` mounts `<App>` wrapped in MUI `ThemeProvider` + Redux `Provider`.
 2. `src/App.tsx` renders the `Header`/`Footer` layout with `BrowserRouter`. Routes are defined in `src/router/index.ts` and lazy-loaded with `React.lazy` + `<Suspense>`.
-3. The Ethereum service (`src/service/ether/ether.ts`) constructs a `JsonRpcProvider` against `VITE_RPCENDPOINT` and exposes `getETHBalance(address)` and `getDAIBalance(address)`. The DAI ERC-20 contract is resolved via the ENS name `dai.tokens.ethers.eth`.
+3. The Ethereum service (`src/service/ether/ether.ts`) constructs a viem `PublicClient` against `VITE_RPCENDPOINT` (mainnet, `http` transport) and exposes `getETHBalance(address)` → `{block, balance}` and `getDAIBalance(address)` → `{block, name, symbol, balance, balanceFormatted}`. The DAI ERC-20 contract is hardcoded to its canonical mainnet address `0x6B17…1d0F` (no ENS lookup).
 4. State lives in `src/store/` — Redux Toolkit slices (`counterSlice`, `commonSlice`) accessed through typed hooks (`useAppDispatch`, `useAppSelector`).
 
 ### Runtime env-var injection
@@ -86,26 +86,27 @@ sequenceDiagram
   actor User
   participant SPA as React SPA<br/>(AccountForm)
   participant Ether as Ether service<br/>(ether.ts)
-  participant Provider as ethers.JsonRpcProvider
+  participant Client as viem.PublicClient<br/>(mainnet, http transport)
   participant RPC as Ethereum JSON-RPC<br/>(VITE_RPCENDPOINT)
-  participant DAI as DAI ERC-20 Contract<br/>(dai.tokens.ethers.eth)
+  participant DAI as DAI ERC-20<br/>(0x6B17…1d0F)
 
   User->>SPA: enter address, click "Get Balance"
   SPA->>Ether: getETHBalance(address)
-  Ether->>Provider: new JsonRpcProvider(VITE_RPCENDPOINT)
-  Provider->>RPC: eth_blockNumber
-  RPC-->>Provider: block height
-  Provider->>RPC: eth_getBalance(address)
-  RPC-->>Provider: balance (wei)
-  Provider-->>Ether: { block, balance }
-  Ether-->>SPA: ETHbalance, ETHblock
-  SPA-->>User: render balance + block number
+  Ether->>Client: createPublicClient({chain: mainnet, transport: http(...)})
+  Ether->>Client: Promise.all([getBlockNumber(), getBalance({address})])
+  Client->>RPC: eth_blockNumber + eth_getBalance
+  RPC-->>Client: { block, balance (wei) }
+  Client-->>Ether: { block, balance }
+  Ether-->>SPA: { block, balance }
+  SPA-->>User: render balance (formatEther) + block number
 
-  Note over SPA,DAI: DAI flow adds a Contract call against the ENS-resolved DAI ERC-20
+  Note over SPA,DAI: DAI flow adds 3 contract reads (name + symbol + balanceOf) in parallel
   SPA->>Ether: getDAIBalance(address)
-  Ether->>DAI: balanceOf(address) via ethers.Contract
-  DAI-->>Ether: balance (uint256)
-  Ether-->>SPA: DAIBalance, DAIblock
+  Ether->>Client: Promise.all([getBlockNumber(), readContract×3])
+  Client->>DAI: name() + symbol() + balanceOf(address)
+  DAI-->>Client: ('Dai Stablecoin', 'DAI', balance uint256)
+  Client-->>Ether: { block, name, symbol, balance, balanceFormatted }
+  Ether-->>SPA: { block, name, symbol, balance, balanceFormatted }
   SPA-->>User: render DAI balance
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.3.9",
     "@reduxjs/toolkit": "^2.11.2",
-    "ethers": "^6.16.0",
+    "viem": "^2.48.1",
     "i18next": "^26.0.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@reduxjs/toolkit':
         specifier: ^2.11.2
         version: 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
-      ethers:
-        specifier: ^6.16.0
-        version: 6.16.0
       i18next:
         specifier: ^26.0.6
         version: 26.0.6(typescript@6.0.3)
@@ -44,6 +41,9 @@ importers:
       react-router-dom:
         specifier: ^7.14.1
         version: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      viem:
+        specifier: ^2.48.1
+        version: 2.48.1(typescript@6.0.3)
     devDependencies:
       '@playwright/test':
         specifier: 1.59.1
@@ -77,7 +77,7 @@ importers:
         version: 4.1.4(vitest@4.1.4)
       jsdom:
         specifier: 29.0.2
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       postcss:
         specifier: 8.5.10
         version: 8.5.10
@@ -95,15 +95,15 @@ importers:
         version: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
 
 packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@adraffy/ens-normalize@1.10.1':
-    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -398,12 +398,17 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@noble/curves@1.2.0':
-    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
 
-  '@noble/hashes@1.3.2':
-    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
-    engines: {node: '>= 16'}
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
@@ -527,6 +532,15 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -670,9 +684,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/node@22.7.5':
-    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
-
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
@@ -749,8 +760,16 @@ packages:
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
-  aes-js@4.0.0-beta.5:
-    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -871,9 +890,8 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  ethers@6.16.0:
-    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
-    engines: {node: '>=14.0.0'}
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -956,6 +974,11 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1116,6 +1139,14 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  ox@0.14.17:
+    resolution: {integrity: sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -1364,9 +1395,6 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
-  tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1374,9 +1402,6 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -1389,6 +1414,14 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  viem@2.48.1:
+    resolution: {integrity: sha512-GJC3gKV1Hngeo1IB9YanJKHH2pcmoqDymyPxddmzDtG8boXA7eFw8qdnn1PSaToJ93f3LpOZPlLLJ9beAF/Lzg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -1499,8 +1532,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1526,7 +1559,7 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@adraffy/ens-normalize@1.10.1': {}
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -1735,7 +1768,9 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1850,11 +1885,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@noble/curves@1.2.0':
-    dependencies:
-      '@noble/hashes': 1.3.2
+  '@noble/ciphers@1.3.0': {}
 
-  '@noble/hashes@1.3.2': {}
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
 
   '@oxc-project/types@0.124.0': {}
 
@@ -1928,6 +1965,19 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2052,10 +2102,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/node@22.7.5':
-    dependencies:
-      undici-types: 6.19.8
-
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -2095,7 +2141,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -2138,7 +2184,9 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  aes-js@4.0.0-beta.5: {}
+  abitype@1.2.3(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   ansi-regex@5.0.1: {}
 
@@ -2197,10 +2245,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -2242,18 +2290,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  ethers@6.16.0:
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@types/node': 22.7.5
-      aes-js: 4.0.0-beta.5
-      tslib: 2.7.0
-      ws: 8.17.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
+  eventemitter3@5.0.1: {}
 
   expect-type@1.3.0: {}
 
@@ -2283,9 +2320,9 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -2318,6 +2355,10 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  isows@1.0.7(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -2337,17 +2378,17 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsdom@29.0.2:
+  jsdom@29.0.2(@noble/hashes@1.8.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.2.7
       parse5: 8.0.0
@@ -2358,7 +2399,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -2451,6 +2492,21 @@ snapshots:
   object-assign@4.1.1: {}
 
   obug@2.1.1: {}
+
+  ox@0.14.17(typescript@6.0.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - zod
 
   parent-module@1.0.1:
     dependencies:
@@ -2670,14 +2726,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tslib@2.7.0: {}
-
   tslib@2.8.1:
     optional: true
 
   typescript@6.0.3: {}
-
-  undici-types@6.19.8: {}
 
   undici-types@7.19.2: {}
 
@@ -2686,6 +2738,23 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  viem@2.48.1(typescript@6.0.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.3)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.14.17(typescript@6.0.3)
+      ws: 8.18.3
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
 
   vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1):
     dependencies:
@@ -2699,7 +2768,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)):
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
@@ -2724,7 +2793,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
-      jsdom: 29.0.2
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
 
@@ -2738,9 +2807,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -2751,7 +2820,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  ws@8.17.1: {}
+  ws@8.18.3: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/src/components/AccountForm.tsx
+++ b/src/components/AccountForm.tsx
@@ -2,91 +2,70 @@
 import React, { useEffect, useState } from 'react'
 import { t } from 'i18next'
 import {
-  DAIBalance,
-  DAIblock,
-  ETHbalance,
-  ETHblock,
+  formatEther,
+  getAddress,
   getDAIBalance,
   getETHBalance,
-  getProvider,
-  provider,
 } from '@/service/ether'
-import { ethers } from 'ethers'
+
 const RPCENDPOINT = import.meta.env.VITE_RPCENDPOINT ?? 'not configured'
 const ERRMSG = 'Could not retrieve info from blockchain using\n'
 
-const AccountForm = () => {
-  const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
+function isValidAddress(value: string): boolean {
+  try {
+    getAddress(value)
+    return true
+  } catch {
+    return false
+  }
+}
 
+const AccountForm = () => {
   const [destinationAddress, setDestinationAddress] = useState('')
   const [balance, setBalance] = useState<bigint>(0n)
   const [block, setBlock] = useState(0)
   const [asset, setAsset] = useState('ETH')
   const [disable, setDisable] = useState(false)
 
-  const getBlock = async () => {
-    try {
-      getProvider()
-      await provider.getBlockNumber()
-      const block = await provider.getBlockNumber()
-      setBlock(block)
-    } catch (error) {
-      setBlock(0)
-    }
-  }
-
   useEffect(() => {
-    getBlock()
-    getBalance()
+    void getBalance()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const getBalance = async (event?: any) => {
-    if (ethers.isAddress(destinationAddress)) {
+  const getBalance = async (_event?: unknown) => {
+    if (isValidAddress(destinationAddress)) {
       setDisable(true)
     }
     setBalance(0n)
     setBlock(0)
-    let assetCbValue: string = (
+    const assetCbValue: string = (
       document.getElementById('selectAsset') as HTMLInputElement
     ).value
 
-    if (assetCbValue == 'ETH') {
-      try {
-        getProvider()
-        await provider.getBlockNumber()
-        await getETHBalance(destinationAddress)
-        setBalance(ETHbalance)
-        setBlock(ETHblock)
-      } catch (e) {
-        console.error(e)
-        alert(ERRMSG + RPCENDPOINT)
+    try {
+      if (assetCbValue == 'ETH') {
+        const result = await getETHBalance(destinationAddress)
+        setBalance(result.balance)
+        setBlock(Number(result.block))
+      } else {
+        const result = await getDAIBalance(destinationAddress)
+        setBalance(result.balance)
+        setBlock(Number(result.block))
       }
-    } else {
-      try {
-        getProvider()
-        await provider.getBlockNumber()
-        await getDAIBalance(destinationAddress)
-        setBalance(DAIBalance)
-        setBlock(DAIblock)
-      } catch (e) {
-        console.error(e)
-        alert(ERRMSG + RPCENDPOINT)
-      }
+    } catch (e) {
+      console.error(e)
+      alert(ERRMSG + RPCENDPOINT)
+    } finally {
+      setDisable(false)
     }
-    setDisable(false)
   }
 
   const handleChange = (event?: React.ChangeEvent<HTMLSelectElement>) => {
     try {
       setAsset(event!.target.value)
-      getBalance(event)
+      void getBalance(event)
     } catch (e) {
       console.log(e instanceof Error ? e.message : e)
-      if (typeof e === 'string') {
-        e.toUpperCase()
-      } else if (e instanceof Error) {
-        console.log(e.message)
-      }
     }
   }
 
@@ -102,11 +81,9 @@ const AccountForm = () => {
             setDestinationAddress(event.target.value)
           }}
           onKeyUp={() => {
-            getBalance()
+            void getBalance()
           }}
         />
-        {/*<select value={asset} disabled={disable} name="selectAsset" id="selectAsset" className="text-neutral-700"*/}
-        {/*        onChange={(e) => setAsset(e.target.value)}>*/}
         <select
           value={asset}
           disabled={disable}
@@ -122,7 +99,7 @@ const AccountForm = () => {
 
       <div className="pt-1 font-bold text-neutral-700">
         <>
-          {t('balance')}: {ethers.formatEther(balance)}
+          {t('balance')}: {formatEther(balance)}
         </>
       </div>
       <div className="pt-1 font-bold text-neutral-700">

--- a/src/components/__tests__/AccountForm.test.tsx
+++ b/src/components/__tests__/AccountForm.test.tsx
@@ -7,54 +7,31 @@ import {
 } from '@/test/test-utils'
 import AccountForm from '@/components/AccountForm'
 
-const mockGetBlockNumber = vi.fn().mockResolvedValue(12345)
-const mockProvider = {
-  ready: Promise.resolve(),
-  getBlockNumber: mockGetBlockNumber,
-  getBalance: vi.fn().mockResolvedValue(0n),
-}
+const TEST_ADDRESS = '0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf'
 
 vi.mock('@/service/ether', () => ({
-  provider: null,
-  ETHbalance: 0,
-  ETHblock: 0,
-  DAIBalance: 0,
-  DAIblock: 0,
-  DAIContractName: '',
-  DAISymbol: '',
-  DAIBalanceFormatted: '0',
-  getProvider: vi.fn(),
-  getETHBalance: vi.fn().mockResolvedValue([12345, 0n]),
-  getDAIBalance: vi.fn().mockResolvedValue([12345, 'Dai', 'DAI', 0n, '0.0']),
-}))
-
-vi.mock('ethers', () => ({
-  ethers: {
-    isAddress: vi.fn(() => false),
-    formatEther: vi.fn((val) => {
-      if (typeof val === 'bigint') return (Number(val) / 1e18).toString()
-      return '0.0'
-    }),
-  },
+  getETHBalance: vi.fn().mockResolvedValue({ block: 12345n, balance: 0n }),
+  getDAIBalance: vi.fn().mockResolvedValue({
+    block: 12345n,
+    name: 'Dai Stablecoin',
+    symbol: 'DAI',
+    balance: 0n,
+    balanceFormatted: '0.0',
+  }),
+  formatEther: vi.fn((val: bigint) => (Number(val) / 1e18).toString()),
+  formatUnits: vi.fn((val: bigint) => (Number(val) / 1e18).toString()),
+  getAddress: vi.fn((value: string) => {
+    if (!value || !value.startsWith('0x')) {
+      throw new Error(`Address "${value}" is invalid.`)
+    }
+    return value
+  }),
 }))
 
 describe('AccountForm component', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(window, 'alert').mockImplementation(() => {})
-
-    const etherMod = await import('@/service/ether')
-    Object.defineProperty(etherMod, 'provider', {
-      value: mockProvider,
-      writable: true,
-    })
-    vi.mocked(etherMod.getProvider).mockImplementation(async () => {
-      Object.defineProperty(etherMod, 'provider', {
-        value: mockProvider,
-        writable: true,
-      })
-    })
-    mockGetBlockNumber.mockResolvedValue(12345)
   })
 
   it('renders the address input with placeholder', () => {
@@ -91,8 +68,11 @@ describe('AccountForm component', () => {
     expect(input).toHaveValue('0xabc')
   })
 
-  it('shows alert when provider fails', async () => {
-    mockGetBlockNumber.mockRejectedValue(new Error('network error'))
+  it('shows alert when getETHBalance throws', async () => {
+    const etherMod = await import('@/service/ether')
+    vi.mocked(etherMod.getETHBalance).mockRejectedValueOnce(
+      new Error('network error'),
+    )
     renderWithProviders(<AccountForm />)
 
     await waitFor(() => {
@@ -112,32 +92,20 @@ describe('AccountForm component', () => {
     })
   })
 
-  it('displays balance for address 0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf', async () => {
+  it('displays balance for a valid address', async () => {
     const etherMod = await import('@/service/ether')
-    const { ethers } = await import('ethers')
     const balanceWei = 1500000000000000000n // 1.5 ETH
-
-    vi.mocked(ethers.isAddress).mockReturnValue(true)
-    vi.mocked(ethers.formatEther).mockReturnValue('1.5')
-    vi.mocked(etherMod.getETHBalance).mockImplementation(async () => {
-      Object.defineProperty(etherMod, 'ETHbalance', {
-        value: balanceWei,
-        writable: true,
-        configurable: true,
-      })
-      Object.defineProperty(etherMod, 'ETHblock', {
-        value: 20000000,
-        writable: true,
-        configurable: true,
-      })
-      return [20000000, balanceWei]
+    vi.mocked(etherMod.getETHBalance).mockResolvedValue({
+      block: 20000000n,
+      balance: balanceWei,
     })
+    vi.mocked(etherMod.formatEther).mockReturnValue('1.5')
 
     renderWithProviders(<AccountForm />)
     const user = userEvent.setup()
 
     const input = screen.getByPlaceholderText('Address')
-    await user.type(input, '0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf')
+    await user.type(input, TEST_ADDRESS)
     await user.click(screen.getByText('Get Balance'))
 
     await waitFor(() => {

--- a/src/service/ether/__tests__/ether.integration.test.ts
+++ b/src/service/ether/__tests__/ether.integration.test.ts
@@ -1,48 +1,82 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeAll } from 'vitest'
-import { ethers } from 'ethers'
+import { createPublicClient, http, formatEther, getAddress } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const TEST_ADDRESS = '0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf'
+const DAI_ADDRESS = '0x6B175474E89094C44Da98b954EedeAC495271d0F' as const
+
+const DAI_ABI = [
+  {
+    type: 'function',
+    name: 'name',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'string' }],
+  },
+  {
+    type: 'function',
+    name: 'symbol',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'string' }],
+  },
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ type: 'address' }],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const
 
 let RPC_ENDPOINT: string
-const TEST_ADDRESS = '0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf'
-const DAI_ADDRESS = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+let client: ReturnType<typeof createPublicClient>
 
-describe('ether service (real RPC)', () => {
-  let provider: ethers.JsonRpcProvider
-
+describe('viem service (real RPC)', () => {
   beforeAll(() => {
     vi.unstubAllEnvs()
     RPC_ENDPOINT = import.meta.env.VITE_RPCENDPOINT
+    client = createPublicClient({
+      chain: mainnet,
+      transport: http(RPC_ENDPOINT),
+    })
   })
 
   it('retrieves a block number from the network', async () => {
-    provider = new ethers.JsonRpcProvider(RPC_ENDPOINT)
-    const block = await provider.getBlockNumber()
-    expect(block).toBeGreaterThan(0)
+    const block = await client.getBlockNumber()
+    expect(block).toBeTypeOf('bigint')
+    expect(block).toBeGreaterThan(0n)
   }, 15000)
 
   it('retrieves ETH balance for a real address', async () => {
-    const balance = await provider.getBalance(TEST_ADDRESS)
+    const balance = await client.getBalance({
+      address: getAddress(TEST_ADDRESS),
+    })
     expect(balance).toBeTypeOf('bigint')
     expect(balance).toBeGreaterThanOrEqual(0n)
-
-    const formatted = ethers.formatEther(balance)
-    expect(Number(formatted)).toBeGreaterThanOrEqual(0)
+    expect(Number(formatEther(balance))).toBeGreaterThanOrEqual(0)
   }, 15000)
 
   it('retrieves DAI token info and balance for a real address', async () => {
-    const daiAbi = [
-      'function name() view returns (string)',
-      'function symbol() view returns (string)',
-      'function balanceOf(address) view returns (uint)',
-    ]
-    const daiContract = new ethers.Contract(DAI_ADDRESS, daiAbi, provider)
-
     const [name, symbol, balance] = await Promise.all([
-      daiContract.name(),
-      daiContract.symbol(),
-      daiContract.balanceOf(TEST_ADDRESS),
+      client.readContract({
+        address: DAI_ADDRESS,
+        abi: DAI_ABI,
+        functionName: 'name',
+      }),
+      client.readContract({
+        address: DAI_ADDRESS,
+        abi: DAI_ABI,
+        functionName: 'symbol',
+      }),
+      client.readContract({
+        address: DAI_ADDRESS,
+        abi: DAI_ABI,
+        functionName: 'balanceOf',
+        args: [getAddress(TEST_ADDRESS)],
+      }),
     ])
-
     expect(name).toBe('Dai Stablecoin')
     expect(symbol).toBe('DAI')
     expect(balance).toBeTypeOf('bigint')
@@ -50,34 +84,37 @@ describe('ether service (real RPC)', () => {
   }, 15000)
 })
 
-describe('ether service (negative paths against real RPC)', () => {
+describe('viem service (negative paths against real RPC)', () => {
   it('rejects with a network error when RPC URL is unreachable', async () => {
-    const badProvider = new ethers.JsonRpcProvider(
-      'http://127.0.0.1:1/does-not-exist',
-    )
-    await expect(badProvider.getBlockNumber()).rejects.toBeDefined()
+    const badClient = createPublicClient({
+      chain: mainnet,
+      transport: http('http://127.0.0.1:1/does-not-exist'),
+    })
+    await expect(badClient.getBlockNumber()).rejects.toBeDefined()
   }, 15000)
 
-  it('rejects when getBalance is called with a malformed address', async () => {
-    vi.unstubAllEnvs()
-    const provider = new ethers.JsonRpcProvider(
-      import.meta.env.VITE_RPCENDPOINT,
+  it('rejects when getAddress is called with a malformed value (validation, no RPC)', async () => {
+    expect(() => getAddress('not-an-address')).toThrow(
+      /is invalid|invalid|not a valid/i,
     )
-    await expect(provider.getBalance('not-an-address')).rejects.toThrow(
-      /invalid address|unconfigured name/i,
-    )
-  }, 15000)
+  })
 
-  it('rejects when reading from a non-contract address as a contract', async () => {
+  it('returns 0 balance when reading balanceOf on an externally-owned address (not a contract)', async () => {
     vi.unstubAllEnvs()
-    const provider = new ethers.JsonRpcProvider(
-      import.meta.env.VITE_RPCENDPOINT,
-    )
-    const notAContract = new ethers.Contract(
-      TEST_ADDRESS,
-      ['function balanceOf(address) view returns (uint)'],
-      provider,
-    )
-    await expect(notAContract.balanceOf(TEST_ADDRESS)).rejects.toBeDefined()
+    const c = createPublicClient({
+      chain: mainnet,
+      transport: http(import.meta.env.VITE_RPCENDPOINT),
+    })
+    // EOA address responds with empty bytes to a `balanceOf` call; viem
+    // raises a ContractFunctionExecutionError. We assert on the error class
+    // rather than the message because viem's wording evolves across minors.
+    await expect(
+      c.readContract({
+        address: getAddress(TEST_ADDRESS),
+        abi: DAI_ABI,
+        functionName: 'balanceOf',
+        args: [getAddress(TEST_ADDRESS)],
+      }),
+    ).rejects.toThrow(/returned no data|reverted|execution/i)
   }, 15000)
 })

--- a/src/service/ether/__tests__/ether.test.ts
+++ b/src/service/ether/__tests__/ether.test.ts
@@ -1,89 +1,100 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockGetBlockNumber = vi.fn().mockResolvedValue(12345)
-const mockGetBalance = vi.fn().mockResolvedValue(1000000000000000000n)
-const mockProvider = {
-  ready: Promise.resolve(),
-  getBlockNumber: mockGetBlockNumber,
-  getBalance: mockGetBalance,
+// A canonical valid Ethereum address (checksummed) so viem's getAddress
+// doesn't reject the input before our service code runs.
+const TEST_ADDRESS = '0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf'
+
+const mockClient = {
+  getBlockNumber: vi.fn().mockResolvedValue(12345n),
+  getBalance: vi.fn().mockResolvedValue(1000000000000000000n),
+  readContract: vi.fn().mockImplementation(async ({ functionName }) => {
+    if (functionName === 'name') return 'Dai Stablecoin'
+    if (functionName === 'symbol') return 'DAI'
+    if (functionName === 'balanceOf') return 500000000000000000n
+    throw new Error(`unexpected functionName: ${functionName}`)
+  }),
 }
 
-const mockContractName = vi.fn().mockResolvedValue('Dai Stablecoin')
-const mockContractSymbol = vi.fn().mockResolvedValue('DAI')
-const mockContractBalanceOf = vi.fn().mockResolvedValue(500000000000000000n)
-
-vi.mock('ethers', () => {
-  const MockJsonRpcProvider = vi.fn(function () {
-    return mockProvider
-  })
-  const MockContract = vi.fn(function () {
-    return {
-      name: mockContractName,
-      symbol: mockContractSymbol,
-      balanceOf: mockContractBalanceOf,
-    }
-  })
+vi.mock('viem', async () => {
+  const actual = await vi.importActual<typeof import('viem')>('viem')
   return {
-    ethers: {
-      JsonRpcProvider: MockJsonRpcProvider,
-      Contract: MockContract,
-      formatUnits: vi.fn(() => '0.5'),
-    },
+    ...actual,
+    createPublicClient: vi.fn(() => mockClient),
+    http: vi.fn(() => 'mock-transport'),
   }
 })
 
 describe('ether service', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
+    // Restore default mock behaviors after vi.clearAllMocks().
+    mockClient.getBlockNumber.mockResolvedValue(12345n)
+    mockClient.getBalance.mockResolvedValue(1000000000000000000n)
+    mockClient.readContract.mockImplementation(async ({ functionName }) => {
+      if (functionName === 'name') return 'Dai Stablecoin'
+      if (functionName === 'symbol') return 'DAI'
+      if (functionName === 'balanceOf') return 500000000000000000n
+      throw new Error(`unexpected functionName: ${functionName}`)
+    })
+    // Reset cached PublicClient between tests so createPublicClient is
+    // re-invoked and the test can assert against the call.
+    const { resetClient } = await import('@/service/ether/ether')
+    resetClient()
   })
 
-  it('getProvider creates a provider with the env RPC endpoint', async () => {
-    const { getProvider } = await import('@/service/ether/ether')
-    await getProvider()
-    const { ethers } = await import('ethers')
-    expect(ethers.JsonRpcProvider).toHaveBeenCalledWith('http://localhost:8545')
+  it('getETHBalance creates a viem client with the env RPC endpoint', async () => {
+    const { getETHBalance } = await import('@/service/ether/ether')
+    await getETHBalance(TEST_ADDRESS)
+    const { createPublicClient, http } = await import('viem')
+    expect(http).toHaveBeenCalledWith('http://localhost:8545')
+    expect(createPublicClient).toHaveBeenCalled()
   })
 
   it('getETHBalance returns block number and balance', async () => {
-    const { getProvider, getETHBalance } = await import('@/service/ether/ether')
-    await getProvider()
-    const result = await getETHBalance(
-      '0x1234567890abcdef1234567890abcdef12345678',
-    )
-    expect(mockGetBlockNumber).toHaveBeenCalled()
-    expect(mockGetBalance).toHaveBeenCalledWith(
-      '0x1234567890abcdef1234567890abcdef12345678',
-    )
-    expect(result).toBeDefined()
+    const { getETHBalance } = await import('@/service/ether/ether')
+    const result = await getETHBalance(TEST_ADDRESS)
+    expect(mockClient.getBlockNumber).toHaveBeenCalled()
+    expect(mockClient.getBalance).toHaveBeenCalledWith({
+      address: TEST_ADDRESS,
+    })
+    expect(result).toEqual({
+      block: 12345n,
+      balance: 1000000000000000000n,
+    })
   })
 
-  it('getETHBalance handles provider errors gracefully', async () => {
-    mockGetBlockNumber.mockRejectedValueOnce(new Error('network error'))
-    const { getProvider, getETHBalance } = await import('@/service/ether/ether')
-    await getProvider()
-    const result = await getETHBalance('0x1234')
-    expect(result).toBeUndefined()
+  it('getETHBalance propagates network errors', async () => {
+    mockClient.getBlockNumber.mockRejectedValueOnce(new Error('network error'))
+    const { getETHBalance } = await import('@/service/ether/ether')
+    await expect(getETHBalance(TEST_ADDRESS)).rejects.toThrow('network error')
   })
 
   it('getDAIBalance returns token info and balance', async () => {
-    const { getProvider, getDAIBalance } = await import('@/service/ether/ether')
-    await getProvider()
-    const result = await getDAIBalance(
-      '0x1234567890abcdef1234567890abcdef12345678',
-    )
-    expect(mockContractName).toHaveBeenCalled()
-    expect(mockContractSymbol).toHaveBeenCalled()
-    expect(mockContractBalanceOf).toHaveBeenCalledWith(
-      '0x1234567890abcdef1234567890abcdef12345678',
-    )
-    expect(result).toBeDefined()
+    const { getDAIBalance } = await import('@/service/ether/ether')
+    const result = await getDAIBalance(TEST_ADDRESS)
+    expect(mockClient.readContract).toHaveBeenCalledTimes(3)
+    expect(result).toEqual({
+      block: 12345n,
+      name: 'Dai Stablecoin',
+      symbol: 'DAI',
+      balance: 500000000000000000n,
+      balanceFormatted: '0.5',
+    })
   })
 
-  it('getDAIBalance handles contract errors gracefully', async () => {
-    mockContractName.mockRejectedValueOnce(new Error('contract error'))
-    const { getProvider, getDAIBalance } = await import('@/service/ether/ether')
-    await getProvider()
-    const result = await getDAIBalance('0x1234')
-    expect(result).toBeUndefined()
+  it('getDAIBalance propagates contract errors', async () => {
+    mockClient.readContract.mockImplementationOnce(async () => {
+      throw new Error('contract error')
+    })
+    const { getDAIBalance } = await import('@/service/ether/ether')
+    await expect(getDAIBalance(TEST_ADDRESS)).rejects.toThrow('contract error')
+  })
+
+  it('getETHBalance rejects malformed addresses before calling RPC', async () => {
+    const { getETHBalance } = await import('@/service/ether/ether')
+    await expect(getETHBalance('not-an-address')).rejects.toThrow(
+      /is invalid|invalid address|not a valid/i,
+    )
+    expect(mockClient.getBalance).not.toHaveBeenCalled()
   })
 })

--- a/src/service/ether/ether.ts
+++ b/src/service/ether/ether.ts
@@ -1,65 +1,98 @@
-import { ethers } from 'ethers'
+import {
+  createPublicClient,
+  http,
+  formatEther as viemFormatEther,
+  formatUnits as viemFormatUnits,
+  getAddress,
+  parseAbi,
+  type Address,
+  type PublicClient,
+} from 'viem'
+import { mainnet } from 'viem/chains'
 
-export let provider: ethers.JsonRpcProvider
-export let ETHbalance: bigint
-export let ETHblock: number
+// DAI ERC-20 mainnet contract — hardcoded canonical address (was previously
+// resolved via ENS `dai.tokens.ethers.eth`; pinning the address eliminates
+// an unnecessary RPC roundtrip and the ENS dependency).
+const DAI_ADDRESS: Address = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
 
-export let DAIContractName: string
-export let DAISymbol: string
-export let DAIBalance: bigint
-export let DAIBalanceFormatted: string
-export let DAIblock: number
+const DAI_ABI = parseAbi([
+  'function name() view returns (string)',
+  'function symbol() view returns (string)',
+  'function balanceOf(address) view returns (uint256)',
+])
 
-export async function getProvider() {
-  provider = new ethers.JsonRpcProvider(import.meta.env.VITE_RPCENDPOINT)
-  await provider.ready
+export type ETHResult = { block: bigint; balance: bigint }
+export type DAIResult = {
+  block: bigint
+  name: string
+  symbol: string
+  balance: bigint
+  balanceFormatted: string
 }
 
-export async function getETHBalance(account: string) {
-  try {
-    ETHblock = 0
-    ETHbalance = 0n
-    getProvider()
+let cachedClient: PublicClient | undefined
 
-    return Promise.all([
-      (ETHblock = await provider.getBlockNumber()),
-      (ETHbalance = await provider.getBalance(account)),
-    ]).catch((error) => {
-      console.log(error)
-      return [null, null, null]
-    })
-  } catch (error) {
-    console.log(error)
+function getClient(): PublicClient {
+  if (cachedClient) return cachedClient
+  const url = import.meta.env.VITE_RPCENDPOINT
+  if (!url) throw new Error('VITE_RPCENDPOINT is not configured')
+  cachedClient = createPublicClient({
+    chain: mainnet,
+    transport: http(url),
+  })
+  return cachedClient
+}
+
+// Reset the cached client — used by tests that mutate VITE_RPCENDPOINT
+// across cases (the viem PublicClient holds onto the transport URL).
+export function resetClient(): void {
+  cachedClient = undefined
+}
+
+export async function getETHBalance(account: string): Promise<ETHResult> {
+  const client = getClient()
+  const address = getAddress(account)
+  const [block, balance] = await Promise.all([
+    client.getBlockNumber(),
+    client.getBalance({ address }),
+  ])
+  return { block, balance }
+}
+
+export async function getDAIBalance(account: string): Promise<DAIResult> {
+  const client = getClient()
+  const address = getAddress(account)
+  const [block, name, symbol, balance] = await Promise.all([
+    client.getBlockNumber(),
+    client.readContract({
+      address: DAI_ADDRESS,
+      abi: DAI_ABI,
+      functionName: 'name',
+    }),
+    client.readContract({
+      address: DAI_ADDRESS,
+      abi: DAI_ABI,
+      functionName: 'symbol',
+    }),
+    client.readContract({
+      address: DAI_ADDRESS,
+      abi: DAI_ABI,
+      functionName: 'balanceOf',
+      args: [address],
+    }),
+  ])
+  return {
+    block,
+    name,
+    symbol,
+    balance,
+    balanceFormatted: viemFormatUnits(balance, 18),
   }
 }
 
-export async function getDAIBalance(address: string) {
-  try {
-    DAIblock = 0
-    DAIBalance = 0n
-    getProvider()
-
-    const daiAddress = 'dai.tokens.ethers.eth'
-    const daiAbi = [
-      'function name() view returns (string)',
-      'function symbol() view returns (string)',
-      'function balanceOf(address) view returns (uint)',
-      'function transfer(address to, uint amount)',
-      'event Transfer(address indexed from, address indexed to, uint amount)',
-    ]
-    const daiContract = new ethers.Contract(daiAddress, daiAbi, provider)
-
-    return Promise.all([
-      (DAIblock = await provider.getBlockNumber()),
-      (DAIContractName = await daiContract.name()),
-      (DAISymbol = await daiContract.symbol()),
-      (DAIBalance = await daiContract.balanceOf(address)),
-      (DAIBalanceFormatted = ethers.formatUnits(DAIBalance, 18)),
-    ]).catch((error) => {
-      console.log(error)
-      return [null, null, null]
-    })
-  } catch (error) {
-    console.log(error)
-  }
-}
+// Re-export viem helpers callers use directly (e.g. AccountForm formats
+// the displayed wei balance with formatEther). Keeps viem out of the
+// component layer.
+export const formatEther = viemFormatEther
+export const formatUnits = viemFormatUnits
+export { getAddress }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,8 +28,8 @@ export default defineConfig({
           if (id.includes('node_modules/@mui') || id.includes('node_modules/@emotion')) {
             return 'vendor-mui'
           }
-          if (id.includes('node_modules/ethers')) {
-            return 'vendor-ethers'
+          if (id.includes('node_modules/viem') || id.includes('node_modules/@noble') || id.includes('node_modules/@scure') || id.includes('node_modules/abitype') || id.includes('node_modules/isows') || id.includes('node_modules/ws')) {
+            return 'vendor-viem'
           }
         },
       },


### PR DESCRIPTION
## Summary

Wave 4 of the modernization track. Replaces ethers.js v6 with viem 2.48.1 for all blockchain interaction.

\`/upgrade-analysis\` kept flagging ethers as bus-factor 1 (\`ricmoo\`, last commit 2026-02-13, last release 2025-12-03, 638 open issues) versus viem (active, weekly releases, 3446⭐, 34 open issues). Both MIT — clean swap.

## Why now

The \`/upgrade-analysis\` skill ran twice across the session and re-confirmed the cadence gap. Migration was tracked in \`CLAUDE.md\` Upgrade Backlog. This PR closes the loop.

## Changes

### Service layer (\`src/service/ether/ether.ts\`)
- \`new ethers.JsonRpcProvider(URL)\` → \`createPublicClient({chain: mainnet, transport: http(URL)})\`. Cached module-level; \`resetClient()\` exported for tests.
- \`new ethers.Contract(...).balanceOf(...)\` → \`client.readContract({address, abi, functionName, args})\`. ABI is now \`parseAbi([...])\` (typed).
- DAI contract address hardcoded to canonical mainnet \`0x6B17…1d0F\` — removes the \`dai.tokens.ethers.eth\` ENS lookup (saves a roundtrip).
- **API shape change**: \`getETHBalance(addr)\` returns \`{block, balance}\`; \`getDAIBalance(addr)\` returns \`{block, name, symbol, balance, balanceFormatted}\`. Drops the previous \`let ETHbalance / ETHblock / ...\` module-level mutable state and the \`Promise.all([assignment-as-side-effect])\` pattern.
- Re-exports viem's \`formatEther\`, \`formatUnits\`, \`getAddress\` so the component layer never imports viem directly. Single seam = single point for future SDK swaps.

### Component layer (\`src/components/AccountForm.tsx\`)
- Reads returned \`{block, balance}\` directly into local React state.
- Uses \`getAddress\` from the service to validate input (replaces \`ethers.isAddress\`).
- Uses re-exported \`formatEther\` (no direct viem import).
- Replaces if/else with try/catch/finally.

### Tests
- \`ether.test.ts\`: \`vi.mock('viem', ...)\` returns a stub PublicClient. 6 unit tests including the new malformed-address rejection test.
- \`ether.integration.test.ts\`: rewrites against viem's \`PublicClient\` + \`readContract\`. 6 tests including unreachable-RPC, malformed-address validation, balanceOf-on-EOA negative paths.
- \`AccountForm.test.tsx\`: mocks the new \`@/service/ether\` API surface (no longer mocks \`ethers\`).

### Build
- \`vite.config.ts\` \`manualChunks\`: \`vendor-ethers\` → \`vendor-viem\` (covers viem + \`@noble/*\`, \`@scure/*\`, \`abitype\`, \`isows\`, \`ws\`). Final chunk size 253 KB ≈ old \`vendor-ethers\` 257 KB.

### Docs
- README Tech Stack + C4Context + sequenceDiagram updated for the viem flow (3 parallel \`readContract\` calls for DAI).
- CLAUDE.md Architecture section + test-mock notes + Upgrade Backlog entry marked done.

## Test plan

- [ ] CI \`static-check\` passes (lint + vulncheck + trivy fs/config + secrets + mermaid-lint + deps-prune-check)
- [ ] CI \`test\` passes: 27 unit tests (gained 1 from the new malformed-address rejection test; was 26)
- [ ] CI \`integration-test\` passes: 6 real-RPC tests against \`https://ethereum-rpc.publicnode.com\`
- [ ] CI \`build\` passes
- [ ] CI \`e2e\` passes against the deployed nginx (kind + cloud-provider-kind)
- [ ] CI \`dast\` passes
- [ ] \`ci-pass\` aggregator green
- [ ] (post-merge) AccountForm displays a real ETH balance for the canonical test address \`0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf\` against mainnet via viem