### PR TITLE
chore(renovate): track workflow env vars (ZAP_VERSION) via inline comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ permissions:
 
 env:
   # Duplicated from Makefile ZAP_VERSION (no shared source between Makefile +
-  # workflow). Renovate tracks the Makefile constant via the inline
-  # `# renovate:` comment; bump both together.
+  # workflow). The annotation below lets Renovate's workflow-yaml customManager
+  # bump this in the same PR as the Makefile constant — no drift.
+  # renovate: datasource=github-releases depName=zaproxy/zaproxy extractVersion=^v(?<version>.*)$
   ZAP_VERSION: 2.17.0
 
 jobs:

--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[\"a-zA-Z0-9_:/-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update workflow env vars (e.g. ZAP_VERSION) via inline renovate comments — keeps the workflow literal in sync with the Makefile constant it duplicates",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n\\s*[A-Z_][A-Z0-9_]*:\\s*[\"']?(?<currentValue>[^\"'\\n]+)[\"']?"
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Outcome of `/renovate` review. Adds a third `customManagers` regex so workflow YAML `# renovate:`-annotated env entries are tracked. Closes the ZAP_VERSION drift gap between the Makefile constant and `ci.yml`'s env block. Verified locally with `make renovate-validate` — `zaproxy/zaproxy` now appears in Renovate's discovered dependency set.