### PR TITLE
refactor: switch SPA runtime config to Pattern C (window.__CONFIG__)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Four-layer test pyramid. Each layer has its own Makefile target, vitest/Playwrig
 |-------|--------|--------|-------|-------|----------------|
 | Unit + Component | `make test` | `vitest.config.ts` (excludes `**/*.integration.test.*`) | `src/store/models/__tests__/`, `src/service/ether/__tests__/ether.test.ts`, `src/components/__tests__/` | ~1s | Pure functions, Redux slices, mocked ether service, components rendered via `renderWithProviders` |
 | Integration | `make integration-test` | `vitest.integration.config.ts` (`include: ['**/*.integration.test.ts']`, 30s timeout, node env) | `src/service/ether/__tests__/ether.integration.test.ts` | ~5s | Ether service against the real `VITE_RPCENDPOINT` (block fetch, ETH/DAI balance, malformed-input negative paths) |
-| E2E (curl) | `make e2e` | `e2e/e2e-test.sh` | KinD + cloud-provider-kind LoadBalancer (kind Docker network IP) | ~30s | nginx routes (`/internal/isalive`, `/internal/isready`, `/publicnode` → 307, SPA fallback, missing asset 404) + verifies `start-nginx.sh` substituted `VITE_RPCENDPOINT` into served JS |
+| E2E (curl) | `make e2e` | `e2e/e2e-test.sh` | KinD + cloud-provider-kind LoadBalancer (kind Docker network IP) | ~30s | nginx routes (`/internal/isalive`, `/internal/isready`, `/publicnode` → 307, SPA fallback, missing asset 404) + verifies `start-nginx.sh` substituted `VITE_RPCENDPOINT` into the inline `window.__CONFIG__` block in `/index.html` |
 | E2E (browser) | `make e2e-browser` | `e2e/playwright.config.ts` + `e2e/account-form.spec.ts` | KinD + cloud-provider-kind + Playwright Chromium | ~45s | AccountForm renders, real RPC roundtrip updates the displayed block number |
 
 Notes:
@@ -73,13 +73,14 @@ This is a React SPA that queries Ethereum blockchain balances (ETH and DAI) via 
 
 - **Pages** (`src/pages/`): Route-level components (`index/` = home, `about/`)
 - **Components** (`src/components/`): `AccountForm` (blockchain query UI), `Counter` (Redux demo), `Layout` (Header/Footer with MUI drawer nav), `Logo`
-- **Ethereum service** (`src/service/ether/ether.ts`): Uses viem's `createPublicClient` (mainnet, http transport) to query ETH balances and DAI token contract reads. Exposes `getETHBalance(addr)` and `getDAIBalance(addr)` returning typed result objects (`{block, balance}` / `{block, name, symbol, balance, balanceFormatted}`). RPC endpoint comes from `VITE_RPCENDPOINT` env var. DAI contract address hardcoded to canonical mainnet `0x6B17…1d0F` (no ENS lookup). Re-exports `formatEther`, `formatUnits`, `getAddress` so the component layer doesn't import viem directly.
+- **Ethereum service** (`src/service/ether/ether.ts`): Uses viem's `createPublicClient` (mainnet, http transport) to query ETH balances and DAI token contract reads. Exposes `getETHBalance(addr)` and `getDAIBalance(addr)` returning typed result objects (`{block, balance}` / `{block, name, symbol, balance, balanceFormatted}`). RPC endpoint comes from `config.VITE_RPCENDPOINT` (resolved at module load via `src/config.ts` — see "Runtime env-var injection" below). DAI contract address hardcoded to canonical mainnet `0x6B17…1d0F` (no ENS lookup). Re-exports `formatEther`, `formatUnits`, `getAddress` so the component layer doesn't import viem directly.
+- **Runtime config** (`src/config.ts`): Single source of truth for env-derived runtime values. Reads `window.__CONFIG__` first (populated by `start-nginx.sh`'s envsubst pass on `index.html.template` in production), falls through to `import.meta.env` when the placeholder is still literal (i.e. `pnpm dev` or test). Both `ether.ts` and `AccountForm.tsx` consume the typed `config` object — no other module reads `import.meta.env.VITE_*` directly.
 - **State** (`src/store/`): Redux Toolkit with slices for `counter` (`counterSlice.ts`) and `common` (`commonSlice.ts`). Uses `configureStore`, `createSlice`, and typed hooks (`useAppDispatch`, `useAppSelector`).
 - **i18n** (`src/locale.ts`): i18next with `react-i18next`, static English translations from `src/locales/en.json`
 
-### Runtime env-var injection
+### Runtime env-var injection (Pattern C)
 
-`Dockerfile.prod` builds with placeholder env values; `start-nginx.sh` runs `envsubst` against the served JS bundles at container startup so `VITE_RPCENDPOINT` can be set per-environment without rebuilding the image. The K8s `ConfigMap` in `k8s/cm.yaml` provides this value in cluster.
+`Dockerfile.prod` is environment-agnostic — Vite's build emits `index.html` containing an inline `<script>` block that sets `window.__CONFIG__ = { VITE_RPCENDPOINT: "${VITE_RPCENDPOINT}", VITE_BASE_URL: "${VITE_BASE_URL}" }`. The build renames it to `index.html.template`. At container startup, `start-nginx.sh` runs `envsubst` against that single file (variables restricted to `$VITE_RPCENDPOINT $VITE_BASE_URL` so unrelated container env doesn't accidentally substitute) and writes the result to `/usr/share/nginx/html/index.html`. The SPA reads `window.__CONFIG__` via `src/config.ts`. Bundled JS is byte-identical across deployments — only `index.html` changes per env. K8s `ConfigMap` in `k8s/cm.yaml` provides values in-cluster.
 
 ### Path Alias
 
@@ -91,7 +92,7 @@ Tailwind CSS v4 with `@tailwindcss/postcss`. Custom colors (`primary`, `secondar
 
 ### Build
 
-Vite 8 with oxc minifier (not terser). Console and debugger statements are stripped in production via `build.oxc.compress` in `vite.config.ts`. Vendor chunks are split via `rolldownOptions.output.manualChunks` (function, not object — Rolldown requirement) into `vendor-react`, `vendor-mui`, and `vendor-ethers`.
+Vite 8 with oxc minifier (not terser). Console and debugger statements are stripped in production via `build.oxc.compress` in `vite.config.ts`. Vendor chunks are split via `rolldownOptions.output.manualChunks` (function, not object — Rolldown requirement) into `vendor-react`, `vendor-mui`, and `vendor-viem` (covers `viem`, `@noble/*`, `@scure/*`, `abitype`, `isows`, `ws`).
 
 ## CI/CD
 
@@ -159,13 +160,14 @@ Last reviewed: 2026-04-19 (post `/upgrade-analysis` Wave 1+2+3 applied). Review 
 - [x] ~~**Wave 4: MUI v7 → v9**~~ — done (2026-04-19). MUI skipped v8 entirely; direct jump v7.3.9 → v9.0.0 (released 2026-04-08). Single breaking change in this codebase: `<Menu MenuListProps={{...}}>` → `<Menu slotProps={{ list: {...} }}>` in `Layout.tsx`. v9's headline changes (sx-prop perf, accessibility, deprecated-API cleanup) didn't affect any of our usage. vendor-mui chunk grew slightly (175 KB → 179 KB).
 - [x] ~~**K8s deployment: enable resource requests/limits**~~ — done (2026-04-19), conservative defaults (cpu 10m/200m, mem 32Mi/64Mi) + per-init `5m/100m` and `16Mi/32Mi`.
 - [x] ~~**K8s deployment: add securityContext**~~ — done (2026-04-19), pod-level `runAsNonRoot:true, runAsUser:101, runAsGroup:101, fsGroup:101, seccompProfile:RuntimeDefault`; container-level `readOnlyRootFilesystem:true, allowPrivilegeEscalation:false, capabilities.drop:[ALL]`. Init container `seed-html` copies baked HTML to a writable emptyDir so `start-nginx.sh`'s envsubst can rewrite the bundled JS at startup. `.trivyignore` cleared.
+- [x] ~~**Wave 5: Pattern C runtime config**~~ — done (2026-04-19). Replaced "envsubst against bundled JS" (Pattern B) with "envsubst against `index.html.template` only" (Pattern C). Vite emits an inline `window.__CONFIG__` script in `index.html` containing literal `${VITE_RPCENDPOINT}`/`${VITE_BASE_URL}` placeholders. `Dockerfile.prod` renames it to `index.html.template`; `start-nginx.sh` substitutes only those two vars at container start. The SPA reads via `src/config.ts` (typed wrapper with placeholder detection + `import.meta.env` fallback for dev/test). Bundled JS is byte-identical across deployments — Trivy/cosign hashes stay stable across env, only `index.html` differs. e2e assertion updated to verify `window.__CONFIG__.VITE_RPCENDPOINT` is substituted in the served `index.html`.
 
 ### Open (post-`/upgrade-analysis` deferred items)
 
 - [ ] **`vite.config.ts` hardcodes `server.port: 8080`** — fine for dev (matches container/k8s/nginx), but PORT env var doesn't propagate there. Low priority; `.env.example` documents the coupling.
-- [ ] **e2e lazy-chunk regex (`assert_any_chunk_contains` in `e2e/e2e-test.sh`) is project-specific** — relies on the well-known prefix list `index|about|vendor-…|i18next|rolldown-runtime`. If a refactor introduces a new chunk basename (e.g. via Vite plugin reshuffle), the env-injection assertion silently misses it. Consider a more permissive enumeration (e.g. probe every `/assets/*.js` referenced anywhere transitively) when this becomes a problem.
+- [x] ~~**e2e lazy-chunk regex (`assert_any_chunk_contains`)**~~ — obsolete after Pattern C migration (2026-04-19). The env-injection assertion now reads `window.__CONFIG__` from served `index.html` directly via `assert_runtime_config_substituted` — no JS chunk traversal.
 - [ ] **No SBOM published with the image** — Pattern A intentionally disables `sbom: true` to keep the GHCR "OS / Arch" tab rendering. If a downstream consumer needs an SPDX SBOM (e.g. `cosign download attestation --predicate-type https://spdx.dev/Document`), opt into Pattern B and accept the GHCR UI regression.
-- [ ] **Architecture diagram tech-strings will drift on every framework bump** — README has 3 Mermaid blocks (C4Context, sequenceDiagram, C4Deployment) that name framework versions (`"React 19.2"`, `"TypeScript 6"`, `"Vite 8"`, `"ethers.js 6.16"`, `"nginx-unprivileged 1.29.8 on :8080"`, `"kindest/node v1.35.1"`). Renovate cannot update these strings. Re-run `/architecture-diagrams` after Wave 4 lands (or any later major bump).
+- [ ] **Architecture diagram tech-strings will drift on every framework bump** — README has 3 Mermaid blocks (C4Context, sequenceDiagram, C4Deployment) that name framework versions (`"React 19.2"`, `"TypeScript 6"`, `"Vite 8"`, `"viem 2"`, `"nginx-unprivileged 1.29.8 on :8080"`, `"kindest/node v1.35.1"`). Renovate cannot update these strings. Re-run `/architecture-diagrams` after any future major bump.
 
 ## Skills
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -8,14 +8,12 @@ COPY package.json pnpm-lock.yaml .npmrc ./
 RUN pnpm install --frozen-lockfile
 COPY . .
 
-# Build-time placeholder values for the SPA's runtime-configurable env vars.
-# Vite bakes these literal `$NAME` strings into the bundle; start-nginx.sh's
-# envsubst replaces them at container startup with the actual runtime values
-# from the env (typically from the k8s ConfigMap). This is the indirection
-# that makes "build once, configure at deploy time" work.
-ENV VITE_RPCENDPOINT='$VITE_RPCENDPOINT' \
-    VITE_BASE_URL='$VITE_BASE_URL'
-RUN pnpm build
+# Pattern C: runtime config is injected by start-nginx.sh's envsubst pass
+# against `index.html.template` (which contains `${VITE_RPCENDPOINT}` etc.
+# inside an inline `window.__CONFIG__` script). No env-var baking required
+# — Vite simply emits index.html as-is with the placeholders. Build is
+# fully environment-agnostic.
+RUN pnpm build && mv dist/index.html dist/index.html.template
 
 # https://hub.docker.com/r/nginxinc/nginx-unprivileged/tags
 FROM nginxinc/nginx-unprivileged:1.29.8-alpine@sha256:30c5bce612513c0fcd49d5a349cb99f7a214d174f7455f7107eeccfd10a68b02 AS server
@@ -23,8 +21,17 @@ FROM nginxinc/nginx-unprivileged:1.29.8-alpine@sha256:30c5bce612513c0fcd49d5a349
 # Patch alpine packages newer than the upstream base image's bake date.
 # Most relevant currently: zlib (CVE-2026-22184, fixed in 1.3.2-r0). The
 # `apk upgrade` requires root; we drop back to UID 101 (nginx) below.
+#
+# Also chown /usr/share/nginx/html — the base image ships it as root:root
+# with a stock index.html. start-nginx.sh's envsubst writes a new index.html
+# at runtime as UID 101, which fails on a root-owned directory. The COPY
+# --chown below only affects copied entries, not the destination directory
+# itself, so we chown explicitly here. Removing the base image's stock
+# index.html in the same step keeps the layer minimal.
 USER root
-RUN apk --no-cache upgrade
+RUN apk --no-cache upgrade \
+ && rm -f /usr/share/nginx/html/index.html \
+ && chown -R nginx:nginx /usr/share/nginx/html
 USER 101
 
 LABEL org.opencontainers.image.title="Web3 Sample App" \

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ deps-playwright: install
 
 #e2e: @ Deploy to KinD (LoadBalancer via cloud-provider-kind) and run curl-based e2e suite
 e2e: kind-create kind-deploy
-	@$(KUBECTL_NS) wait --for=condition=available --timeout=180s deployment/$(APP_NAME)
+	@$(KUBECTL_NS) rollout status deployment/$(APP_NAME) --timeout=180s
 	@bash -c 'set -e; \
 		echo "Waiting for LoadBalancer IP..."; \
 		for i in $$(seq 1 60); do \
@@ -181,7 +181,7 @@ e2e: kind-create kind-deploy
 
 #e2e-browser: @ Run Playwright browser e2e against deployed SPA via LoadBalancer IP
 e2e-browser: kind-create kind-deploy deps-playwright
-	@$(KUBECTL_NS) wait --for=condition=available --timeout=180s deployment/$(APP_NAME)
+	@$(KUBECTL_NS) rollout status deployment/$(APP_NAME) --timeout=180s
 	@bash -c 'set -e; \
 		for i in $$(seq 1 60); do \
 			LB_IP=$$($(KUBECTL_NS) get svc $(APP_NAME) -o jsonpath="{.status.loadBalancer.ingress[0].ip}"); \

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ The SPA is a single React app served from a static nginx image. All blockchain c
 3. The Ethereum service (`src/service/ether/ether.ts`) constructs a viem `PublicClient` against `VITE_RPCENDPOINT` (mainnet, `http` transport) and exposes `getETHBalance(address)` → `{block, balance}` and `getDAIBalance(address)` → `{block, name, symbol, balance, balanceFormatted}`. The DAI ERC-20 contract is hardcoded to its canonical mainnet address `0x6B17…1d0F` (no ENS lookup).
 4. State lives in `src/store/` — Redux Toolkit slices (`counterSlice`, `commonSlice`) accessed through typed hooks (`useAppDispatch`, `useAppSelector`).
 
-### Runtime env-var injection
+### Runtime env-var injection (Pattern C)
 
-`Dockerfile.prod` builds with placeholder env values, then `start-nginx.sh` runs `envsubst` against the served JS bundles at container startup so `VITE_RPCENDPOINT` can be set per-environment without rebuilding the image. The K8s `ConfigMap` in `k8s/cm.yaml` provides this value in cluster.
+`Dockerfile.prod` is environment-agnostic — Vite emits `index.html` containing an inline `<script>` block that sets `window.__CONFIG__ = { VITE_RPCENDPOINT: "${VITE_RPCENDPOINT}", VITE_BASE_URL: "${VITE_BASE_URL}" }`. The build renames it to `index.html.template`. At container startup, `start-nginx.sh` runs `envsubst` against that single template (restricted variable list — only `$VITE_RPCENDPOINT` and `$VITE_BASE_URL` are substituted) and writes the result to `index.html`. The SPA reads `window.__CONFIG__` via `src/config.ts`, which falls through to `import.meta.env` when the placeholders are still literal (i.e. `pnpm dev`). The K8s `ConfigMap` in `k8s/cm.yaml` provides the runtime values in cluster — see [`src/config.ts`](src/config.ts), [`index.html`](index.html), and [`start-nginx.sh`](start-nginx.sh).
 
 ### Path alias
 
@@ -127,7 +127,7 @@ C4Deployment
     Deployment_Node(cluster, "KinD cluster", "kindest/node v1.35.1") {
       Deployment_Node(ns, "Namespace: web3") {
         Deployment_Node(pod, "Pod (Deployment, replicas=1)") {
-          Container(init, "seed-html (init)", "Copies baked HTML to writable emptyDir")
+          Container(init, "seed-html (init)", "Copies image's html dir (assets + index.html.template) to writable emptyDir")
           Container(nginx, "web3-sample-app", "nginx-unprivileged 1.29.8 on :8080")
         }
         ContainerDb(cm, "ConfigMap", "web3-sample-app-config — VITE_RPCENDPOINT, VITE_BASE_URL, PORT")
@@ -142,10 +142,10 @@ C4Deployment
   Rel(envoy, svc, "Routes to")
   Rel(svc, nginx, "Routes to")
   Rel(nginx, cm, "Reads env from", "envFrom")
-  Rel(nginx, rpc, "JSON-RPC", "via baked + envsubst'd URL")
+  Rel(nginx, rpc, "JSON-RPC", "URL from window.__CONFIG__ (envsubst'd index.html)")
 ```
 
-The `seed-html` init container copies the baked SPA bundle from the read-only image filesystem into a writable `emptyDir` mounted at `/usr/share/nginx/html`. The main container's `start-nginx.sh` then runs `envsubst` against the bundled JS (replacing the literal `$VITE_RPCENDPOINT` placeholder Vite baked at build time with the value from the ConfigMap) before nginx starts. This is what makes "build once, configure at deploy time" work despite `readOnlyRootFilesystem: true` on the main container.
+The `seed-html` init container copies the baked SPA bundle (`assets/` plus `index.html.template`) from the read-only image filesystem into a writable `emptyDir` mounted at `/usr/share/nginx/html`. The main container's `start-nginx.sh` then runs `envsubst` against `index.html.template` only (variables restricted to `$VITE_RPCENDPOINT $VITE_BASE_URL`) and writes the result to `index.html`. The SPA reads the substituted values via `window.__CONFIG__` at boot. The `assets/` JS bundles are byte-identical across environments, so consumers can verify by digest and Trivy/Cosign signatures stay consistent. This is what makes "build once, configure at deploy time" work despite `readOnlyRootFilesystem: true` on the main container — and the initContainer image MUST stay in lockstep with the main container image (both are patched to the same tag by `kind-deploy` via `KIND_IMAGE_PATCH`).
 
 ## Testing
 
@@ -155,7 +155,7 @@ Four test layers, each with its own Makefile target, config, and CI job:
 |-------|--------|-------|---------------|----------------|
 | Unit + Component | `make test` | `src/store/models/__tests__/`, `src/service/ether/__tests__/ether.test.ts`, `src/components/__tests__/` | jsdom (vitest, in-process) | Pure functions, Redux slices, mocked ether service, components rendered via `renderWithProviders` |
 | Integration | `make integration-test` | `src/service/ether/__tests__/ether.integration.test.ts` | node (vitest, real network) | Ether service against the real `VITE_RPCENDPOINT` (block fetch, ETH/DAI balance, malformed-input negatives) |
-| E2E — HTTP | `make e2e` | `e2e/e2e-test.sh` | KinD + cloud-provider-kind LoadBalancer | nginx routes (`/internal/isalive`, `/internal/isready`, `/publicnode` → 307, SPA fallback, missing asset 404) + verifies `start-nginx.sh` substituted `VITE_RPCENDPOINT` into served JS |
+| E2E — HTTP | `make e2e` | `e2e/e2e-test.sh` | KinD + cloud-provider-kind LoadBalancer | nginx routes (`/internal/isalive`, `/internal/isready`, `/publicnode` → 307, SPA fallback, missing asset 404) + verifies `start-nginx.sh` substituted `VITE_RPCENDPOINT` into the inline `window.__CONFIG__` in served `index.html` |
 | E2E — Browser | `make e2e-browser` | `e2e/playwright.config.ts`, `e2e/account-form.spec.ts` | KinD + cloud-provider-kind + Playwright Chromium | AccountForm renders + real RPC roundtrip updates the displayed block number |
 
 ```bash
@@ -230,7 +230,7 @@ xdg-open "http://${service_ip}:8080"
 kubectl delete -f ./k8s --namespace=web3
 ```
 
-The K8s ConfigMap (`k8s/cm.yaml`) provides `VITE_RPCENDPOINT` to the running pod; `start-nginx.sh` substitutes it into the served JS at startup.
+The K8s ConfigMap (`k8s/cm.yaml`) provides `VITE_RPCENDPOINT` to the running pod; `start-nginx.sh` substitutes it into the inline `window.__CONFIG__` script in `/index.html` at startup (Pattern C — see [Runtime env-var injection](#runtime-env-var-injection-pattern-c)).
 
 ## Available Make Targets
 

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -52,40 +52,34 @@ assert_redirect_target() {
   fi
 }
 
-assert_any_chunk_contains() {
-  # SPA chunk-splits via Vite + Rolldown. The VITE_RPCENDPOINT value lands in
-  # whichever chunk imports the ether service — index-*.js by default, but
-  # could move under refactor. Crawl primary scripts referenced from index.html
-  # AND any lazy chunks they import via `"./assets/..."` strings.
+assert_runtime_config_substituted() {
+  # Pattern C: start-nginx.sh runs envsubst on index.html.template at container
+  # start, producing /index.html with `window.__CONFIG__.VITE_RPCENDPOINT` set
+  # to the real RPC URL from container env. Verify both that the inline script
+  # is present AND that the placeholder was replaced (no literal `${VAR}`).
   local pattern="$1"
-  local primary_assets lazy_chunks asset_urls
-  primary_assets=$(curl -sf "$BASE/" | grep -oE '/assets/[^"'\'']+\.js' | sort -u || true)
-  # Rolldown emits lazy-chunk references as bare basenames (NOT quoted, NOT
-  # as `./assets/...` paths). Match the well-known chunk prefixes. CSS and
-  # non-existent siblings get filtered later by the curl probe (404s skipped).
-  lazy_chunks=$(for a in $primary_assets; do
-    curl -sf "${BASE}${a}" \
-      | grep -oE '\b(index|about|vendor-[a-z]+|i18next|rolldown-runtime)-[A-Za-z0-9_-]{8}\b' \
-      | awk '{print "/assets/" $0 ".js"}' || true
-  done | sort -u || true)
-  asset_urls=$(printf '%s\n%s\n' "$primary_assets" "$lazy_chunks" | sort -u | sed '/^$/d')
-  if [[ -z "$asset_urls" ]]; then
-    echo "FAIL: no /assets/*.js URLs found in served HTML"
+  local body
+  body=$(curl -sf "$BASE/" || true)
+  if ! echo "$body" | grep -q 'window.__CONFIG__'; then
+    echo "FAIL: served index.html missing window.__CONFIG__ inline script"
     FAIL=$((FAIL + 1))
     return
   fi
-  for asset in $asset_urls; do
-    if curl -sf "${BASE}${asset}" | grep -q "$pattern"; then
-      echo "PASS: ${BASE}${asset} contains '$pattern' (Vite baked VITE_RPCENDPOINT into bundle)"
-      PASS=$((PASS + 1))
-      return
-    fi
-  done
-  echo "FAIL: '$pattern' not found in any served chunk: $(echo "$asset_urls" | tr '\n' ' ')"
-  FAIL=$((FAIL + 1))
+  if echo "$body" | grep -q '\${VITE_RPCENDPOINT}'; then
+    echo "FAIL: envsubst did not replace \${VITE_RPCENDPOINT} placeholder"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if echo "$body" | grep -q "VITE_RPCENDPOINT: \"$pattern\""; then
+    echo "PASS: window.__CONFIG__.VITE_RPCENDPOINT substituted with '$pattern'"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: window.__CONFIG__.VITE_RPCENDPOINT does not contain '$pattern'"
+    FAIL=$((FAIL + 1))
+  fi
 }
 
-echo "=== E2E suite against $BASE (expecting RPC=$EXPECTED_RPC injected into JS) ==="
+echo "=== E2E suite against $BASE (expecting RPC=$EXPECTED_RPC injected into index.html) ==="
 
 # Health probes (nginx custom routes)
 assert_status GET "$BASE/internal/isalive" 200
@@ -108,9 +102,10 @@ assert_status GET "$BASE/assets/does-not-exist.js" 404
 # Public RPC redirect (nginx /publicnode -> 307 to public RPC)
 assert_redirect_target "$BASE/publicnode" 307 "ethereum-rpc.publicnode.com"
 
-# Bundle env coverage — VITE_RPCENDPOINT must appear in some served chunk
-# (Vite bakes it at build time; if it's missing, the SPA cannot reach the RPC).
-assert_any_chunk_contains "$EXPECTED_RPC"
+# Pattern C runtime config — VITE_RPCENDPOINT must be substituted into the
+# inline window.__CONFIG__ script in /index.html by start-nginx.sh's envsubst
+# pass. If the placeholder is still literal, container startup is broken.
+assert_runtime_config_substituted "$EXPECTED_RPC"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/index.html
+++ b/index.html
@@ -9,6 +9,19 @@
     <title>web3-sample-app</title>
   </head>
   <body>
+    <!--
+      Runtime configuration injection (Pattern C). The placeholders below
+      are substituted by `start-nginx.sh`'s envsubst pass at container start
+      with values from the container env (k8s ConfigMap / docker -e). In
+      `pnpm dev`, the placeholders pass through untouched and src/config.ts
+      detects them and falls through to import.meta.env from `.env`.
+    -->
+    <script>
+      window.__CONFIG__ = {
+        VITE_RPCENDPOINT: "${VITE_RPCENDPOINT}",
+        VITE_BASE_URL: "${VITE_BASE_URL}"
+      };
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/AccountForm.tsx
+++ b/src/components/AccountForm.tsx
@@ -7,8 +7,9 @@ import {
   getDAIBalance,
   getETHBalance,
 } from '@/service/ether'
+import { config } from '@/config'
 
-const RPCENDPOINT = import.meta.env.VITE_RPCENDPOINT ?? 'not configured'
+const RPCENDPOINT = config.VITE_RPCENDPOINT || 'not configured'
 const ERRMSG = 'Could not retrieve info from blockchain using\n'
 
 function isValidAddress(value: string): boolean {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,70 @@
+/**
+ * Runtime configuration for the SPA — bridges the gap between server env
+ * vars (in production) and Vite build-time env (during local dev / tests).
+ *
+ * Production flow:
+ *   1. Container starts.
+ *   2. start-nginx.sh runs `envsubst` against `index.html.template`,
+ *      writing real env values into the inline `window.__CONFIG__` script.
+ *   3. Browser loads index.html → `window.__CONFIG__` is populated before
+ *      any module code runs.
+ *   4. This file reads from `window.__CONFIG__` and exposes a typed object.
+ *
+ * Local dev / unit tests:
+ *   - `pnpm dev` serves index.html as-is with literal `${VITE_RPCENDPOINT}`
+ *     placeholder strings inside `window.__CONFIG__`. We detect the
+ *     placeholder pattern and fall through to `import.meta.env`, which
+ *     Vite populates from `.env` automatically.
+ *   - jsdom tests can stub `window.__CONFIG__` directly.
+ */
+
+declare global {
+  interface Window {
+    __CONFIG__?: {
+      VITE_RPCENDPOINT?: string
+      VITE_BASE_URL?: string
+    }
+  }
+}
+
+export interface AppConfig {
+  VITE_RPCENDPOINT: string
+  VITE_BASE_URL: string
+}
+
+const PLACEHOLDER_RE = /^\$\{[A-Z_]+\}$/
+
+function isUnreplacedPlaceholder(v: string | undefined): v is string {
+  return typeof v === 'string' && PLACEHOLDER_RE.test(v)
+}
+
+function pick(
+  runtimeValue: string | undefined,
+  buildTimeValue: string | undefined,
+  fallback: string,
+): string {
+  if (runtimeValue && !isUnreplacedPlaceholder(runtimeValue))
+    return runtimeValue
+  if (buildTimeValue) return buildTimeValue
+  return fallback
+}
+
+function readConfig(): AppConfig {
+  const runtime = typeof window !== 'undefined' ? window.__CONFIG__ : undefined
+  return {
+    VITE_RPCENDPOINT: pick(
+      runtime?.VITE_RPCENDPOINT,
+      import.meta.env.VITE_RPCENDPOINT as string | undefined,
+      '',
+    ),
+    VITE_BASE_URL: pick(
+      runtime?.VITE_BASE_URL,
+      import.meta.env.VITE_BASE_URL as string | undefined,
+      '/api/',
+    ),
+  }
+}
+
+// Cached at module load. Tests that need to override should use vi.mock
+// or set window.__CONFIG__ before importing modules that depend on this.
+export const config: AppConfig = readConfig()

--- a/src/service/ether/ether.ts
+++ b/src/service/ether/ether.ts
@@ -9,6 +9,7 @@ import {
   type PublicClient,
 } from 'viem'
 import { mainnet } from 'viem/chains'
+import { config } from '@/config'
 
 // DAI ERC-20 mainnet contract — hardcoded canonical address (was previously
 // resolved via ENS `dai.tokens.ethers.eth`; pinning the address eliminates
@@ -34,7 +35,7 @@ let cachedClient: PublicClient | undefined
 
 function getClient(): PublicClient {
   if (cachedClient) return cachedClient
-  const url = import.meta.env.VITE_RPCENDPOINT
+  const url = config.VITE_RPCENDPOINT
   if (!url) throw new Error('VITE_RPCENDPOINT is not configured')
   cachedClient = createPublicClient({
     chain: mainnet,

--- a/start-nginx.sh
+++ b/start-nginx.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env sh
 #
-# Substitute runtime env vars into the bundled SPA JS, then start nginx.
-# Vite bakes literal `$VITE_*` placeholders into the bundle (per Dockerfile.prod
-# build args); envsubst replaces them at startup with the values from the env
-# (typically supplied by the k8s ConfigMap).
+# Pattern C runtime config injection: substitute env vars into a single
+# file (`index.html`) at container startup, then start nginx. The SPA reads
+# `window.__CONFIG__` (set by the inline script in index.html) — no JS
+# bundle rewriting required.
+#
+# Source template lives at /usr/share/nginx/html/index.html.template
+# (renamed from index.html in Dockerfile.prod). Output is written to
+# /usr/share/nginx/html/index.html on every container start.
 
 set -eu
 
-cp /usr/share/nginx/html/assets/*.js /tmp
-EXISTING_VARS=$(printenv | awk -F= '{print "$"$1}' | paste -sd,)
-export EXISTING_VARS
+TEMPLATE=/usr/share/nginx/html/index.html.template
+OUT=/usr/share/nginx/html/index.html
 
-for file in /tmp/*.js; do
-  envsubst "${EXISTING_VARS}" < "${file}" > "/usr/share/nginx/html/assets/$(basename "${file}")"
-done
+# Restrict envsubst to known SPA config vars so unrelated env entries don't
+# accidentally get substituted into the HTML if they happen to share a name
+# with something in the template.
+envsubst '$VITE_RPCENDPOINT $VITE_BASE_URL' < "$TEMPLATE" > "$OUT"
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary

Migrates SPA runtime config from **Pattern B** (envsubst over bundled JS) to **Pattern C** (envsubst over `index.html.template` only). Bundled JS is now byte-identical across deployments — Trivy/cosign hashes stay stable across environments, only `/index.html` differs per env.

- New `src/config.ts` — typed wrapper around `window.__CONFIG__` with placeholder detection + `import.meta.env` fallback for dev/test
- `ether.ts` + `AccountForm.tsx` consume `config.VITE_RPCENDPOINT` instead of `import.meta.env.*` directly
- `Dockerfile.prod` — drop `ENV VITE_*=...`; rename `dist/index.html` → `dist/index.html.template`; chown `/usr/share/nginx/html` so UID 101 can write substituted output
- `start-nginx.sh` — single-file envsubst restricted to `$VITE_RPCENDPOINT $VITE_BASE_URL`
- e2e — replace `assert_any_chunk_contains` (crawled bundled JS) with `assert_runtime_config_substituted` (asserts on served `/index.html`)
- Makefile `e2e`/`e2e-browser` — `kubectl rollout status` instead of `wait --for=condition=available` to avoid LB routing to terminating pod during rolling update
- README + CLAUDE.md — document Pattern C, refresh deployment diagram description, update test-layer table

## Local validation
- [x] `make check` — prettier + 27 unit/component tests + tsc + vite build
- [x] `make docker-smoke-test` — prod image boots `/internal/isalive`
- [x] `make e2e` — 12/12 PASS, `window.__CONFIG__.VITE_RPCENDPOINT` substituted in served HTML
- [x] `make dast` — FAIL-NEW: 0, WARN-NEW: 6 (all pre-existing)
- [x] `make ci-run` — local act run, ci-pass succeeded
- [x] `make mermaid-lint` — README + CLAUDE.md diagrams parse

## Test plan
- [ ] CI all green (static-check, test, integration-test, build, e2e, dast)
- [ ] Tag-push pipeline (will fire on next `vN.N.N` tag): build-for-scan → Trivy CRITICAL/HIGH → smoke test → multi-arch publish → cosign keyless sign