### PR TITLE
chore: /renovate pass — non-capturing groups + cleaner .mise.toml comments

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,11 @@
 [tools]
-# Source of truth for tool versions across local dev and CI.
-# Renovate tracks these via the `mise` manager and the `.mise.toml`
-# custom regex below (for inline `# renovate:` annotations on aqua: pins).
+# Source of truth for tool versions across local dev and CI. Renovate's
+# native `mise` manager extracts every entry below — there is NO custom
+# regex over this file (a duplicate manager would produce two PRs per
+# bump). The plain `# Tracked:` comments are documentation only — they
+# do not drive Renovate. Per `/renovate` skill, do NOT use the literal
+# `renovate:` keyword in comments here, since that invites someone to
+# re-add the bad custom manager and re-introduce the duplicate-PR bug.
 
 # Node.js LTS — kept in sync with engines.node range in package.json.
 node = "24"
@@ -9,28 +13,30 @@ node = "24"
 # pnpm package manager (canonical core mise backend).
 pnpm = "10.33.0"
 
-# renovate: datasource=github-releases depName=nektos/act extractVersion=^v(?<version>.*)$
+# Tracked: github-tags github.com/nektos/act
 "aqua:nektos/act" = "0.2.88"
 
-# renovate: datasource=github-releases depName=hadolint/hadolint extractVersion=^v(?<version>.*)$
+# Tracked: github-tags github.com/hadolint/hadolint
 "aqua:hadolint/hadolint" = "2.14.0"
 
-# renovate: datasource=github-releases depName=kubernetes/kubectl extractVersion=^v(?<version>.*)$
+# Tracked: github-tags github.com/kubernetes/kubectl
 "aqua:kubernetes/kubectl" = "1.36.0"
 
-# renovate: datasource=github-releases depName=kubernetes-sigs/kind extractVersion=^v(?<version>.*)$
+# Tracked: github-tags github.com/kubernetes-sigs/kind
+# KIND_NODE_IMAGE in Makefile is bumped together with this — see KinD
+# release notes for the matching node image (not independently trackable).
 "aqua:kubernetes-sigs/kind" = "0.31.0"
 
-# renovate: datasource=github-releases depName=mikefarah/yq extractVersion=^v(?<version>.*)$
+# Tracked: github-tags github.com/mikefarah/yq
 "aqua:mikefarah/yq" = "4.53.2"
 
-# renovate: datasource=github-releases depName=aquasecurity/trivy extractVersion=^v(?<version>.*)$
+# Tracked: github-tags github.com/aquasecurity/trivy
 "aqua:aquasecurity/trivy" = "0.70.0"
 
-# renovate: datasource=github-releases depName=gitleaks/gitleaks extractVersion=^v(?<version>.*)$
+# Tracked: github-tags github.com/gitleaks/gitleaks
 "aqua:gitleaks/gitleaks" = "8.30.1"
 
-# renovate: datasource=npm depName=renovate
+# Tracked: npm registry (renovate package).
 "npm:renovate" = "43.150.0"
 
 # Note: cloud-provider-kind runs as a Docker container (registry.k8s.io/...)

--- a/renovate.json
+++ b/renovate.json
@@ -44,7 +44,7 @@
       "description": "Update Makefile tool versions via inline renovate comments",
       "managerFilePatterns": ["/^Makefile$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+\\s*[?:]?=\\s*(?<currentValue>[^\\s]+)"
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: extractVersion=(?<extractVersion>[^\\s]+))?(?: registryUrl=(?<registryUrl>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+\\s*[?:]?=\\s*(?<currentValue>[^\\s]+)"
       ]
     },
     {
@@ -52,7 +52,7 @@
       "description": "Update workflow env vars (e.g. ZAP_VERSION) via inline renovate comments — keeps the workflow literal in sync with the Makefile constant it duplicates",
       "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n\\s*[A-Z_][A-Z0-9_]*:\\s*[\"']?(?<currentValue>[^\"'\\n]+)[\"']?"
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: extractVersion=(?<extractVersion>[^\\s]+))?(?: registryUrl=(?<registryUrl>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?\\n\\s*[A-Z_][A-Z0-9_]*:\\s*[\"']?(?<currentValue>[^\"'\\n]+)[\"']?"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Pass-through cleanup from `/renovate` skill review. Validator was already green pre-change; both edits are future-proofing.

- `renovate.json`: customManagers regex (Makefile + workflow) updated to use non-capturing `(?:...)?` groups (matching the skill's canonical pattern) and to capture an optional `registryUrl=` field so future Helm-chart annotations parse correctly.
- `.mise.toml`: rewrote the `# renovate: datasource=...` comments as plain `# Tracked: ...` doc comments. The native `mise` manager extracts entries directly without reading comments — leaving the `renovate:` keyword in invited future contributors to re-add a custom regex (which produces duplicate PRs alongside the native manager).

Validator stats unchanged: `mise=10, regex=4, total=95 deps`, 0 `validationError`.

## Test plan

- [x] `make renovate-validate` — clean (mise=10, regex=4, total=95)
- [x] `make test` — 35/35 passing
- [x] `make build` — clean
- [x] `mise install` — all tools resolve
- [ ] CI green on this PR