### PR TITLE
docs: hoist hero diagram above tech-stack table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@
 
 Reference React SPA that queries ETH and DAI ERC-20 balances from the Ethereum blockchain via viem, packaged as a non-root nginx container and deployable to Kubernetes.
 
+```mermaid
+C4Context
+    title System Context — Web3 Sample App
+
+    Person(user, "End User", "Browser, supplies an Ethereum address")
+    System(spa, "Web3 Sample App", "React 19 SPA, viem 2, nginx-served")
+    System_Ext(rpc, "Ethereum JSON-RPC", "viem PublicClient, mainnet, http transport via VITE_RPCENDPOINT")
+    System_Ext(dai, "DAI ERC-20 Contract", "0x6B17…1d0F on Ethereum mainnet")
+
+    Rel(user, spa, "Uses", "HTTPS")
+    Rel(spa, rpc, "getBalance / getBlockNumber", "JSON-RPC over HTTPS")
+    Rel(spa, dai, "balanceOf(address)", "Contract call via JSON-RPC")
+```
+
 | Component | Technology |
 |-----------|------------|
 | Language | TypeScript 6.x (`moduleResolution: "bundler"`) |
@@ -22,20 +36,6 @@ Reference React SPA that queries ETH and DAI ERC-20 balances from the Ethereum b
 | CI/CD | GitHub Actions, Renovate (platform automerge) |
 | Code quality | Prettier, hadolint, Trivy (fs+config), gitleaks |
 | Tool versioning | mise (single source of truth in `.mise.toml`) |
-
-```mermaid
-C4Context
-    title System Context — Web3 Sample App
-
-    Person(user, "End User", "Browser, supplies an Ethereum address")
-    System(spa, "Web3 Sample App", "React 19 SPA, viem 2, nginx-served")
-    System_Ext(rpc, "Ethereum JSON-RPC", "viem PublicClient, mainnet, http transport via VITE_RPCENDPOINT")
-    System_Ext(dai, "DAI ERC-20 Contract", "0x6B17…1d0F on Ethereum mainnet")
-
-    Rel(user, spa, "Uses", "HTTPS")
-    Rel(spa, rpc, "getBalance / getBlockNumber", "JSON-RPC over HTTPS")
-    Rel(spa, dai, "balanceOf(address)", "Contract call via JSON-RPC")
-```
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

`/readme` review found one HIGH section-order finding: the hero Mermaid C4Context diagram was below the Tech Stack table. Per skill canonical order: description (#3) → hero visual (#4) → tech stack (#5). The hero is the 10-second visual hook; the tech stack answers "what do I need to recognise?" — both useful, but the visual hook should land first.

No content changed — both blocks moved as-is.

Other review items: all greps clean (no banned patterns, no credentials, no broken anchors, no malformed tables, no duplicate slugs, every code fence tagged), Mermaid lint passes, every Makefile target documented, tech-stack accuracy verified against package.json/Dockerfile/.mise.toml, description factual against source-of-truth.

One LOW deviation kept as-is: `## Testing` as H2 between Architecture and Build & Package. Skill prefers Testing as H3 inside Build & Package, but the substantive 4-layer pyramid table justifies the standalone H2 for this project.

## Test plan

- [x] `make mermaid-lint` passes
- [ ] CI green on this PR
- [ ] Visual sanity on github.com — hero diagram should render above the tech stack table