### PR TITLE
chore: retire redundant apk upgrade in Dockerfile.prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -18,19 +18,20 @@ RUN pnpm build && mv dist/config.js dist/config.js.template
 # https://hub.docker.com/r/nginxinc/nginx-unprivileged/tags
 FROM nginxinc/nginx-unprivileged:1.30.0-alpine@sha256:3edc5c2de0338c1416dd9dd826c8f76a42bcb4a9d51ab6ff8af227b424be5766 AS server
 
-# Patch alpine packages newer than the upstream base image's bake date.
-# Most relevant currently: zlib (CVE-2026-22184, fixed in 1.3.2-r0). The
-# `apk upgrade` requires root; we drop back to UID 101 (nginx) below.
-#
-# Also chown /usr/share/nginx/html — the base image ships it as root:root
-# with a stock index.html. start-nginx.sh's envsubst writes a new index.html
-# at runtime as UID 101, which fails on a root-owned directory. The COPY
+# chown /usr/share/nginx/html — the base image ships it as root:root with
+# a stock index.html. start-nginx.sh's envsubst writes a new index.html at
+# runtime as UID 101, which fails on a root-owned directory. The COPY
 # --chown below only affects copied entries, not the destination directory
 # itself, so we chown explicitly here. Removing the base image's stock
 # index.html in the same step keeps the layer minimal.
+#
+# A previous `apk upgrade` step was retired 2026-05-07 — nginx-unprivileged
+# 1.30.0-alpine ships zlib-1.3.2-r0 (the CVE-2026-22184 fix that the apk
+# upgrade was originally added to backport) and Trivy scans the base image
+# at 0 HIGH/CRITICAL. Renovate keeps the base image current; the CI Trivy
+# image-scan gate catches any post-bake CVEs.
 USER root
-RUN apk --no-cache upgrade \
- && rm -f /usr/share/nginx/html/index.html \
+RUN rm -f /usr/share/nginx/html/index.html \
  && chown -R nginx:nginx /usr/share/nginx/html
 USER 101
 


### PR DESCRIPTION
## Summary

Per `/upgrade-analysis` Phase 4 §"Container-base-image variant" rule. The `USER root → apk --no-cache upgrade → USER 101` block was added to backport zlib CVE-2026-22184 (fixed in `1.3.2-r0`). The current base image `nginxinc/nginx-unprivileged:1.30.0-alpine` already ships `zlib-1.3.2-r0`, so the upgrade is dead weight.

## Verification

| Check | Result |
|---|---|
| `apk info -v zlib` in `1.30.0-alpine` | `zlib-1.3.2-r0` (fixed version) |
| `trivy image` against base | 0 HIGH/CRITICAL |
| `trivy image` against rebuilt `web3-sample-app:0.0.18` | 0 HIGH/CRITICAL |
| `make docker-smoke-test` | PASS |

## What stays

The `rm + chown` portion of the RUN block is kept — those still need root and are independent of the upgrade step. The USER root → USER 101 round-trip is preserved.

## Future-proofing

If a future Alpine package CVE lands before the next `nginx-unprivileged` release, the CI Trivy image-scan gate (Pattern A Gate 2) catches it. The response is either Renovate bumping the base image or adding a `.trivyignore` entry with a documented removal trigger — NOT re-adding a generic `apk upgrade` step.

## Test plan

- [x] zlib version verified in base
- [x] Trivy 0 HIGH/CRITICAL against rebuilt image
- [x] Smoke test passes locally
- [ ] CI green on this PR