### PR TITLE
chore: ship-it pass — README + CLAUDE.md describe three-stage Caddy build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ The `docker` job in `ci.yml` ships images on tag pushes; on non-tag pushes it ru
 ## Docker
 
 - **Dockerfile**: Dev image (Node alpine + pnpm dev server on port 8080); `corepack enable pnpm` (no `npm install -g`). See `Dockerfile` for the pinned base image digest.
-- **Dockerfile.prod**: Multi-stage build (Node alpine builder → `caddy:2.11.3-alpine` on port 8080, non-root `USER 1000:1000`); installs `gettext` so `start-caddy.sh` can `envsubst` the runtime config; OCI labels (artifacthub, vendor, license) baked in via `LABEL` instructions; both stages pin base images by SHA256 digest. See `Dockerfile.prod` for the pinned tags.
+- **Dockerfile.prod**: Three-stage build — (1) `node:24-alpine` builder produces the Vite bundle; (2) `caddy:2.11.3-builder-alpine` runs `xcaddy build v2.11.3 --replace github.com/go-jose/go-jose/v3=…@v3.0.5` to rebuild Caddy with the CVE-2026-34986 fix (transitive Go JOSE DoS — Caddy 2.11.3 ships v3.0.4; v3.0.5 has the patch but no Caddy release carries it yet); (3) `caddy:2.11.3-alpine` runtime, with the rebuilt binary copied in over the bundled one, `gettext` added for `start-caddy.sh`'s envsubst pass, `cap_net_bind_service` stripped from `/usr/bin/caddy` (so the binary execs cleanly under K8s `capabilities.drop:[ALL]`), non-root `USER 1000:1000`. All three stages pin base images by SHA256 digest. OCI labels (artifacthub, vendor, license) on the runtime stage. See `Dockerfile.prod` for the pinned tags.
 - **`packageManager` field** in `package.json` pins pnpm so corepack uses the project-declared version.
 - **`.dockerignore`**: Excludes `node_modules`, `dist`, `.git`, `e2e`, `zap-output`, `playwright-report`, `test-results`, `.env`.
 - **`.hadolint.yaml`**: Configures hadolint rule ignores for Dockerfile linting.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ make image-build         # dev image (Node alpine + pnpm dev server)
 make image-build-prod    # production image (Caddy 2 on 8080)
 ```
 
-The production Dockerfile is multi-stage: `node:24.16.0-alpine` builder → `caddy:2.11.3-alpine`. Both Dockerfiles use `pnpm install --frozen-lockfile`, pin base images by SHA256 digest, and copy lockfiles before source for layer caching. The final image runs as non-root (UID 1000); the build adds `gettext` (for `envsubst`) and strips `cap_net_bind_service` from `/usr/bin/caddy` so the binary execs cleanly under `securityContext.capabilities.drop:[ALL]` in K8s.
+The production Dockerfile is three-stage: `node:24.16.0-alpine` builder → `caddy:2.11.3-builder-alpine` (runs `xcaddy build v2.11.3 --replace github.com/go-jose/go-jose/v3=…@v3.0.5` to rebuild Caddy with the CVE-2026-34986 fix — Caddy 2.11.3 still pins the vulnerable go-jose v3.0.4 as an indirect dep, and no newer Caddy release carries the bump yet) → `caddy:2.11.3-alpine` runtime, with the rebuilt binary copied over the bundled one. Both Dockerfiles use `pnpm install --frozen-lockfile`, pin base images by SHA256 digest, and copy lockfiles before source for layer caching. The final image runs as non-root (UID 1000); the build adds `gettext` (for `envsubst`) and strips `cap_net_bind_service` from `/usr/bin/caddy` so the binary execs cleanly under `securityContext.capabilities.drop:[ALL]` in K8s.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary

`/ship-it` Stage 2 cross-reference of `README.md` + `CLAUDE.md` against the post-Caddy-migration state surfaced one factual gap: both docs described `Dockerfile.prod` as a two-stage build (Node alpine builder → `caddy:2.11.3-alpine`), missing the intermediate `xcaddy` stage that PR #102's follow-up commit added to close CVE-2026-34986.

Now both docs accurately describe the three-stage shape:
1. `node:24.16.0-alpine` — Vite build
2. `caddy:2.11.3-builder-alpine` — `xcaddy build v2.11.3 --replace github.com/go-jose/go-jose/v3=…@v3.0.5` (Caddy 2.11.3 still pins vulnerable go-jose v3.0.4 as an indirect dep; no newer Caddy release carries the bump yet)
3. `caddy:2.11.3-alpine` — runtime, with the rebuilt binary copied over the bundled one, `gettext` added for envsubst, `cap_net_bind_service` stripped, non-root `USER 1000:1000`

Naming the CVE inline gives future maintainers the trigger for retiring the xcaddy stage: when a Caddy release ships go-jose v3.0.5+ as the indirect pin, the replace directive becomes a no-op and the intermediate stage can collapse back to a direct COPY.

## Also fixed out-of-band (no commit)

GitHub repo "About" description bumped from `runtime-config nginx` to `runtime-config Caddy 2` via `gh repo edit --description`. `docker/metadata-action` reads it into the OCI image's `org.opencontainers.image.description` label on every build, so every subsequent image now carries the correct framework reference.

## Test plan
- [x] `make ci` clean
- [ ] CI green on this PR