### PR TITLE
chore: ship-it — dependency/tool upgrades + project-review fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
           ignore-unfixed: true
+          trivyignores: .trivyignore
 
       # ===============================================================
       # GATE 2.5 — container structure test (USER, entrypoint, labels, files)

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: cleanup-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: cleanup-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -11,27 +11,27 @@
 node = "24"
 
 # pnpm package manager (canonical core mise backend).
-pnpm = "11.3.0"
+pnpm = "11.8.0"
 
 # Tracked: github-tags github.com/nektos/act
-"aqua:nektos/act" = "0.2.88"
+"aqua:nektos/act" = "0.2.89"
 
 # Tracked: github-tags github.com/hadolint/hadolint
 "aqua:hadolint/hadolint" = "2.14.0"
 
 # Tracked: github-tags github.com/kubernetes/kubectl
-"aqua:kubernetes/kubectl" = "1.36.1"
+"aqua:kubernetes/kubectl" = "1.36.2"
 
 # Tracked: github-tags github.com/kubernetes-sigs/kind
 # KIND_NODE_IMAGE in Makefile is bumped together with this — see KinD
 # release notes for the matching node image (not independently trackable).
-"aqua:kubernetes-sigs/kind" = "0.31.0"
+"aqua:kubernetes-sigs/kind" = "0.32.0"
 
 # Tracked: github-tags github.com/mikefarah/yq
-"aqua:mikefarah/yq" = "4.53.2"
+"aqua:mikefarah/yq" = "4.53.3"
 
 # Tracked: github-tags github.com/aquasecurity/trivy
-"aqua:aquasecurity/trivy" = "0.70.0"
+"aqua:aquasecurity/trivy" = "0.71.2"
 
 # Tracked: github-tags github.com/gitleaks/gitleaks
 "aqua:gitleaks/gitleaks" = "8.30.1"
@@ -40,7 +40,7 @@ pnpm = "11.3.0"
 "aqua:GoogleContainerTools/container-structure-test" = "1.22.1"
 
 # Tracked: npm registry (renovate package).
-"npm:renovate" = "43.150.0"
+"npm:renovate" = "43.235.1"
 
 # Note: cloud-provider-kind runs as a Docker container (registry.k8s.io/...)
 # pinned via CLOUD_PROVIDER_KIND_VERSION in the Makefile + Renovate.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,15 @@
 # Trivy ignore list — entries here are tracked in CLAUDE.md "Upgrade Backlog".
 # Remove an entry once the corresponding backlog item ships.
 
-# (No active ignores — k8s securityContext + resource limits shipped 2026-04-19.)
+# Base-image (caddy:2.11.4-alpine → alpine 3.23) OS-package CVEs whose fixes are
+# NOT yet in the alpine 3.23 repo — `apk update && apk upgrade --simulate` finds
+# no newer package as of 2026-06-22, so the Dockerfile's `apk --no-cache upgrade`
+# cannot patch them yet. They affect the caddy 2.11.3 base too (pre-existing,
+# not introduced by the 2.11.4 bump). Reachability is nil: caddy is a static Go
+# binary that dynamically links NONE of these libs (verified via `ldd`), so the
+# served workload never exercises openssl/libxml2/libexpat code paths. The
+# `apk --no-cache upgrade` step pulls the fixes automatically once alpine 3.23
+# ships them; the `exp:` dates auto-expire these waivers to force re-evaluation.
+CVE-2026-45447 exp:2026-07-22
+CVE-2026-45186 exp:2026-07-22
+CVE-2026-6732 exp:2026-07-22

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 All commands go through the Makefile. Use `make help` to list targets.
 
 ```bash
-make deps           # install mise + all pinned tools (node, pnpm, hadolint, kubectl, kind, yq, trivy, gitleaks, act)
+make deps           # install mise + all pinned tools (node, pnpm, hadolint, kubectl, kind, yq, trivy, gitleaks, act, container-structure-test, renovate)
 make install        # pnpm install (uses --frozen-lockfile when CI=true)
 make build          # tsc + vite build (depends on install)
 make lint           # prettier --check + hadolint
@@ -40,7 +40,7 @@ make cleanup-images # delete untagged GHCR images, keep 5 (called by cleanup-ima
 
 ## Tool Versions (mise)
 
-`.mise.toml` is the single source of truth for every pinned tool: Node.js, pnpm, hadolint, kubectl, kind, yq, Trivy, gitleaks, act, and `npm:renovate`. `make deps` bootstraps mise via `https://mise.run` (installs to `~/.local/bin`, no sudo) and then runs `mise install` to provision the rest. CI uses `jdx/mise-action` so local and CI read the same `.mise.toml`. Renovate tracks updates via the native `mise` manager.
+`.mise.toml` is the single source of truth for every pinned tool: Node.js, pnpm, hadolint, kubectl, kind, yq, Trivy, gitleaks, act, container-structure-test, and `npm:renovate`. `make deps` bootstraps mise via `https://mise.run` (installs to `~/.local/bin`, no sudo) and then runs `mise install` to provision the rest. CI uses `jdx/mise-action` so local and CI read the same `.mise.toml`. Renovate tracks updates via the native `mise` manager.
 
 Three Docker-image versions stay pinned as Makefile constants (with `# renovate:` annotations) because mise can't manage Docker images: `MERMAID_CLI_VERSION` (mermaid lint), `ZAP_VERSION` (DAST), `CLOUD_PROVIDER_KIND_VERSION` (KinD LoadBalancer controller). `KIND_NODE_IMAGE` is also a Makefile constant but is bumped together with the `aqua:kubernetes-sigs/kind` mise pin (see KinD release notes for matched node image — not independently trackable).
 
@@ -127,7 +127,7 @@ The `docker` job in `ci.yml` ships images on tag pushes; on non-tag pushes it ru
 ## Docker
 
 - **Dockerfile**: Dev image (Node alpine + pnpm dev server on port 8080); `corepack enable pnpm` (no `npm install -g`). See `Dockerfile` for the pinned base image digest.
-- **Dockerfile.prod**: Three-stage build — (1) `node:24-alpine` builder produces the Vite bundle; (2) `caddy:2.11.3-builder-alpine` runs `xcaddy build v2.11.3 --replace github.com/go-jose/go-jose/v3=…@v3.0.5` to rebuild Caddy with the CVE-2026-34986 fix (transitive Go JOSE DoS — Caddy 2.11.3 ships v3.0.4; v3.0.5 has the patch but no Caddy release carries it yet); (3) `caddy:2.11.3-alpine` runtime, with the rebuilt binary copied in over the bundled one, `gettext` added for `start-caddy.sh`'s envsubst pass, `cap_net_bind_service` stripped from `/usr/bin/caddy` (so the binary execs cleanly under K8s `capabilities.drop:[ALL]`), non-root `USER ${APP_UID}:${APP_GID}` (default `1000:1000`, build-arg overridable). The listen port is single-sourced through `ARG APP_INTERNAL_PORT=8080` → `ENV PORT` → Caddyfile `:{$PORT:8080}` → `EXPOSE`, so the K8s ConfigMap `PORT` actually drives the listen port. A `HEALTHCHECK` probes `/internal/isalive` via busybox `wget` (literal flag timings, `${HEALTHCHECK_HOST}:${PORT}` CMD body). All three stages pin base images by SHA256 digest. OCI labels (artifacthub, vendor, license) on the runtime stage. See `Dockerfile.prod` for the pinned tags.
+- **Dockerfile.prod**: Three-stage build — (1) `node:24-alpine` builder produces the Vite bundle; (2) `caddy:2.11.4-builder-alpine` runs `xcaddy build v2.11.4` with `GOTOOLCHAIN=go1.26.4` to rebuild Caddy's stdlib past the Go MIME-header DoS (CVE-2026-42504; the vanilla `caddy:2.11.4-alpine` binary ships Go 1.26.3, still vulnerable — verified via `trivy image`). Caddy 2.11.4 already pins go-jose/v3 v3.0.5, so the earlier `--replace` workaround for CVE-2026-34986 is retired; (3) `caddy:2.11.4-alpine` runtime, with the rebuilt binary copied in over the bundled one, `gettext` added for `start-caddy.sh`'s envsubst pass, `cap_net_bind_service` stripped from `/usr/bin/caddy` (so the binary execs cleanly under K8s `capabilities.drop:[ALL]`), non-root `USER ${APP_UID}:${APP_GID}` (default `1000:1000`, build-arg overridable). The listen port is single-sourced through `ARG APP_INTERNAL_PORT=8080` → `ENV PORT` → Caddyfile `:{$PORT:8080}` → `EXPOSE`, so the K8s ConfigMap `PORT` actually drives the listen port. A `HEALTHCHECK` probes `/internal/isalive` via busybox `wget` (literal flag timings, `${HEALTHCHECK_HOST}:${PORT}` CMD body). All three stages pin base images by SHA256 digest. OCI labels (artifacthub, vendor, license) on the runtime stage. See `Dockerfile.prod` for the pinned tags.
 - **`packageManager` field** in `package.json` pins pnpm so corepack uses the project-declared version.
 - **`.dockerignore`**: Excludes `node_modules`, `dist`, `.git`, `e2e`, `zap-output`, `playwright-report`, `test-results`, `.env`.
 - **`.env.example`**: Committed source of truth for operator-tunable values (`VITE_RPCENDPOINT`, `APP_INTERNAL_PORT`, e2e/Make timeouts). Copy to gitignored `.env` to override locally; shell scripts source it, the Makefile mirrors it as `?=` defaults.
@@ -151,9 +151,10 @@ The `docker` job in `ci.yml` ships images on tag pushes; on non-tag pushes it ru
 
 ## Upgrade Backlog
 
-Last reviewed: 2026-06-16 (post `/project-review` apply — Node toolchain-alignment guard + Renovate cross-manager group, `.env.example` parameter externalization, CI change-gate `!failure() && !cancelled()` hardening, Renovate `pinDigests` collision + `platformAutomerge` race fixes, e2e header/asset coverage, in-image HEALTHCHECK, container-structure-test gate, SPDX SBOM artifact + cosign attestation, Caddyfile `$PORT`/`$PUBLIC_RPC_URL` externalization, Dockerfile UID/port ARGs).
+Last reviewed: 2026-06-22 (`/ship-it` — Stage 1 upgrades: caddy 2.11.3→2.11.4 + retired the go-jose `--replace` workaround (2.11.4 ships go-jose v3.0.5; kept the GOTOOLCHAIN stdlib rebuild for CVE-2026-42504), node 24.16.0→24.17.0, kind 0.31→0.32 + KIND_NODE_IMAGE v1.35.1→v1.36.1, pnpm 11.3→11.8, mise tool patches (act/kubectl/yq/trivy 0.70→0.71.2/renovate), react-router-dom 7.18 + viem 2.53; plus the `/project-review` apply — Renovate `Node` cross-manager group across mise + dockerfile managers, dropped redundant per-rule `automerge: true`, cleanup workflows `cancel-in-progress: false`, README H1 rename + tightened `cosign verify` identity-regexp + provisioned-tools/host-prereq doc, container-structure-test added to tool enumerations, Skills-table path corrections, C4Deployment element trim). Prior (2026-06-16): Node toolchain-alignment guard, `.env.example` parameter externalization, CI change-gate `!failure() && !cancelled()` hardening, Renovate `pinDigests` collision + `platformAutomerge` race fixes, e2e header/asset coverage, in-image HEALTHCHECK, container-structure-test gate, SPDX SBOM artifact + cosign attestation, Caddyfile `$PORT`/`$PUBLIC_RPC_URL` externalization, Dockerfile UID/port ARGs.
 
 - [ ] **Architecture diagram tech-strings drift** — README's C4 diagrams embed framework version strings (e.g. `"React 19 SPA, viem 2"`, `"Caddy 2 on :8080"`). Renovate cannot update these. Re-run `/architecture-diagrams` after any major bump.
+- [ ] **`.trivyignore` waivers for 3 base-image OS CVEs** — `CVE-2026-45447` (openssl), `CVE-2026-45186` (libexpat), `CVE-2026-6732` (libxml2) are present in the `caddy:2.11.4-alpine`/alpine-3.23 base; fixes are not yet in the alpine 3.23 repo (`apk upgrade` has no newer package), so they're waived with `exp:2026-07-22`. Reachability is nil (caddy is a static Go binary linking none of them). The Dockerfile's `apk --no-cache upgrade` pulls the fixes automatically once alpine ships them — remove the `.trivyignore` entries when `apk upgrade --simulate` shows the patched versions, or the waivers auto-expire on 2026-07-22 (re-evaluate then). `@types/node` 26 (major typings) is left to Renovate's type-definitions group.
 
 ## Skills
 
@@ -167,7 +168,7 @@ Use the following skills when working on related files:
 | `README.md` | `/readme` |
 | `.github/workflows/*.{yml,yaml}` | `/ci-workflow` |
 | `Dockerfile`, `Dockerfile.prod` (when changing publish pipeline) | `/harden-image-pipeline` |
-| Any file under `e2e/`, `tests/integration/`, or new test layers | `/test-coverage-analysis` |
-| Any markdown with ` ```mermaid `, or files under `docs/diagrams/` | `/architecture-diagrams` |
+| Any file under `e2e/`, `src/**/__tests__/*.integration.test.ts`, or new test layers | `/test-coverage-analysis` |
+| Any markdown with ` ```mermaid ` (diagrams are currently inline in README.md / CLAUDE.md) | `/architecture-diagrams` |
 
 When spawning subagents, always pass conventions from the respective skill into the agent's prompt.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/node/tags
-FROM node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
+FROM node:24.17.0-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6
 RUN apk --no-cache add git
 RUN corepack enable pnpm
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/node/tags
-FROM node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS builder
+FROM node:24.17.0-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS builder
 RUN apk --no-cache add git
 RUN corepack enable pnpm
 
@@ -15,29 +15,24 @@ COPY . .
 RUN pnpm build && mv dist/config.js dist/config.js.template
 
 # https://hub.docker.com/_/caddy/tags
-# Builder stage: rebuild Caddy with go-jose v3 bumped past CVE-2026-34986.
-# Caddy 2.11.3 (latest stable as of 2026-05-12) pins `github.com/go-jose/
-# go-jose/v3 v3.0.4` as an indirect dep; v3.0.5 ships the fix (Go JOSE
-# DoS via crafted JWE). Until a newer Caddy releases with the bumped
-# dep, `xcaddy --replace` produces a functionally-identical binary with
-# the patched module — the supported upstream way to apply a transitive
-# CVE fix without waiting on Caddy's release cadence.
-FROM caddy:2.11.3-builder-alpine@sha256:52575959b1eeee9900869325a953d71e4c521ab9102dd5cce07d429ea8246b85 AS caddy-builder
-# Build with a Go toolchain past the stdlib MIME-header DoS (CVE-2026-42504,
-# fixed in Go 1.26.4). The builder image ships Go 1.26.3; GOTOOLCHAIN makes
-# `go build` fetch + use the patched toolchain, recompiling caddy's stdlib.
-# The version below is Renovate-tracked via a Dockerfile.prod customManager
-# (datasource=golang-version) in renovate.json.
+# Builder stage: rebuild Caddy with a Go toolchain past the stdlib
+# MIME-header DoS (CVE-2026-42504, fixed in Go 1.26.4). caddy:2.11.4-alpine
+# ships a binary built with Go 1.26.3 (verified via `trivy image` —
+# stdlib HIGH still present), so the vanilla image is vulnerable;
+# GOTOOLCHAIN makes `go build` fetch + use the patched toolchain,
+# recompiling caddy's stdlib. The version below is Renovate-tracked via a
+# Dockerfile.prod customManager (datasource=golang-version) in renovate.json.
+# Note: Caddy 2.11.4 already pins go-jose/v3 v3.0.5, so the earlier
+# `--replace` workaround for CVE-2026-34986 is retired.
+FROM caddy:2.11.4-builder-alpine@sha256:0ff10d4b83af453e5526b1c3cd7ae43396832aa8a2a55311d624f6812b33767d AS caddy-builder
 ENV GOTOOLCHAIN=go1.26.4
-RUN xcaddy build v2.11.3 \
-      --replace github.com/go-jose/go-jose/v3=github.com/go-jose/go-jose/v3@v3.0.5 \
-      --output /caddy
+RUN xcaddy build v2.11.4 --output /caddy
 
 # Runtime stage: copy the rebuilt caddy binary over the one shipped in
-# caddy:2.11.3-alpine, then add envsubst + strip file caps + create the
+# caddy:2.11.4-alpine, then add envsubst + strip file caps + create the
 # non-root app user. Keeping the same runtime base preserves the
 # image's working dir (/srv), default CMD, and OCI labels we add below.
-FROM caddy:2.11.3-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794 AS server
+FROM caddy:2.11.4-alpine@sha256:ed26d6d77aaec5366102f2abb4eeba98ebd356159b49c2ed6e20181ecddb27a7 AS server
 
 # Build-time knobs (non-root identity, listen port, healthcheck host). Override
 # with `--build-arg` per environment; defaults match k8s/cm.yaml + the Caddyfile.
@@ -47,7 +42,7 @@ ARG APP_INTERNAL_PORT=8080
 ARG HEALTHCHECK_HOST=localhost
 
 USER root
-# - Replace the bundled /usr/bin/caddy with the rebuilt one (CVE-2026-34986).
+# - Replace the bundled /usr/bin/caddy with the rebuilt one (Go-stdlib CVE-2026-42504).
 # - `gettext` provides `envsubst` for Pattern C config injection.
 # - `libcap` provides `setcap`, used to strip the `cap_net_bind_service=ep`
 #   file capability from `/usr/bin/caddy`. The Caddy image ships that file

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ MERMAID_CLI_VERSION := 11.15.0
 
 # Bumped together with aqua:kubernetes-sigs/kind in .mise.toml — see KinD
 # release notes for the matching node image. Not independently trackable.
-KIND_NODE_IMAGE := v1.35.1
+KIND_NODE_IMAGE := v1.36.1
 
 # renovate: datasource=github-releases depName=zaproxy/zaproxy extractVersion=^v(?<version>.*)$
 ZAP_VERSION := 2.17.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/web3-sample-app)
 
-# Web3 Sample App
+# Ethereum Balance Viewer — React SPA
 
 Reference **React 19 SPA** that reads **ETH and DAI ERC-20 balances** from Ethereum mainnet entirely in the browser via **viem 2** (no backend) — runtime-configured through a non-root **Caddy 2** container (Pattern-C `/config.js` injection) and deployable to Kubernetes.
 
@@ -33,7 +33,7 @@ C4Context
 | Web3 | viem 2 (`createPublicClient`, `http`, `readContract`, `parseAbi`) |
 | i18n | i18next + react-i18next (English bundled) |
 | Testing | Vitest 4, React Testing Library, jsdom, Playwright (Chromium) |
-| Container | Builder: `node:24.16.0-alpine`; runtime: `caddy:2.11.3-alpine` (port 8080, runs as UID 1000; `cap_net_bind_service` stripped from the binary so it execs cleanly under `securityContext.capabilities.drop:[ALL]`) |
+| Container | Builder: `node:24.17.0-alpine`; runtime: `caddy:2.11.4-alpine` (port 8080, runs as UID 1000; `cap_net_bind_service` stripped from the binary so it execs cleanly under `securityContext.capabilities.drop:[ALL]`) |
 | Orchestration | Kubernetes (manifests under `k8s/`); local KinD via Makefile |
 | CI/CD | GitHub Actions, Renovate (platform automerge) |
 | Code quality | Prettier, hadolint, Trivy (fs+config), gitleaks |
@@ -42,7 +42,7 @@ C4Context
 ## Quick Start
 
 ```bash
-make deps       # install mise + all pinned tools (node, pnpm, hadolint, kubectl, kind, yq, trivy, gitleaks, act)
+make deps       # install mise + all pinned tools (node, pnpm, hadolint, kubectl, kind, yq, trivy, gitleaks, act, container-structure-test, renovate)
 make install    # pnpm install
 make build      # tsc + vite build
 make test       # run unit tests
@@ -59,7 +59,9 @@ make run        # start dev server, then open http://localhost:8080
 | [curl](https://curl.se/) | latest | Bootstraps `mise` in `make deps` |
 | [mise](https://mise.jdx.dev/) | latest | Manages every other tool (auto-installed by `make deps`) |
 
-`make deps` installs [mise](https://mise.jdx.dev/) into `~/.local/bin` (no sudo) and then runs `mise install` against the pinned `.mise.toml` to provision: Node.js, pnpm, hadolint, kubectl, kind, yq, Trivy, gitleaks, act.
+`make deps` installs [mise](https://mise.jdx.dev/) into `~/.local/bin` (no sudo) and then runs `mise install` against the pinned `.mise.toml` to provision: Node.js, pnpm, hadolint, kubectl, kind, yq, Trivy, gitleaks, act, container-structure-test, renovate.
+
+> The `image-*`, `docker-smoke-test`, `dast`, and `cleanup-*` targets shell out to host-provided tools that mise does not manage — `docker` (and, for the GHCR cleanup targets, [`gh`](https://cli.github.com/) + `jq`). Install those separately if you run those targets locally.
 
 ## Architecture
 
@@ -126,8 +128,7 @@ C4Deployment
     Container(envoy, "cloud-provider-kind + kindccm envoy", "Per-Service LB proxy on the kind Docker network")
     Deployment_Node(cluster, "KinD cluster (namespace: web3)", "kindest/node") {
       Deployment_Node(pod, "Pod (Deployment, replicas=1)") {
-        Container(init, "seed-html (init)", "Copies bundled assets + index.html + config.js.template into writable emptyDir")
-        Container(caddy, "web3-sample-app", "Caddy 2 on :8080; envsubst /config.js at boot")
+        Container(caddy, "web3-sample-app", "Caddy 2 on :8080; seed-html initContainer seeds assets into emptyDir, then envsubst /config.js at boot")
       }
       ContainerDb(cm, "ConfigMap", "web3-sample-app-config: VITE_RPCENDPOINT, VITE_BASE_URL, PORT")
       Container(svc, "K8s Service", "type: LoadBalancer, port 8080 → pod :8080")
@@ -179,7 +180,7 @@ make image-build         # dev image (Node alpine + pnpm dev server)
 make image-build-prod    # production image (Caddy 2 on 8080)
 ```
 
-The production Dockerfile is three-stage: `node:24.16.0-alpine` builder → `caddy:2.11.3-builder-alpine` (runs `xcaddy build v2.11.3 --replace github.com/go-jose/go-jose/v3=…@v3.0.5` to rebuild Caddy with the CVE-2026-34986 fix — Caddy 2.11.3 still pins the vulnerable go-jose v3.0.4 as an indirect dep, and no newer Caddy release carries the bump yet) → `caddy:2.11.3-alpine` runtime, with the rebuilt binary copied over the bundled one. Both Dockerfiles use `pnpm install --frozen-lockfile`, pin base images by SHA256 digest, and copy lockfiles before source for layer caching. The final image runs as non-root (UID 1000); the build adds `gettext` (for `envsubst`) and strips `cap_net_bind_service` from `/usr/bin/caddy` so the binary execs cleanly under `securityContext.capabilities.drop:[ALL]` in K8s.
+The production Dockerfile is three-stage: `node:24.17.0-alpine` builder → `caddy:2.11.4-builder-alpine` (runs `xcaddy build v2.11.4` with `GOTOOLCHAIN=go1.26.4` to rebuild Caddy's stdlib past the Go MIME-header DoS CVE-2026-42504 — the vanilla `caddy:2.11.4-alpine` binary ships Go 1.26.3 and is still flagged by Trivy; Caddy 2.11.4 already pins go-jose v3.0.5 so the earlier `--replace` workaround is retired) → `caddy:2.11.4-alpine` runtime, with the rebuilt binary copied over the bundled one. Both Dockerfiles use `pnpm install --frozen-lockfile`, pin base images by SHA256 digest, and copy lockfiles before source for layer caching. The final image runs as non-root (UID 1000); the build adds `gettext` (for `envsubst`) and strips `cap_net_bind_service` from `/usr/bin/caddy` so the binary execs cleanly under `securityContext.capabilities.drop:[ALL]` in K8s.
 
 ## Deployment
 
@@ -373,7 +374,7 @@ Verify a published image's signature:
 
 ```bash
 cosign verify ghcr.io/andriykalashnykov/web3-sample-app:<tag> \
-  --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/web3-sample-app/.+' \
+  --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/web3-sample-app/\.github/workflows/ci\.yml@refs/tags/v.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 

--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -32,7 +32,7 @@ fileExistenceTests:
     shouldExist: true
 
 commandTests:
-  - name: "caddy is the CVE-2026-34986-patched 2.11.3 build"
+  - name: "caddy is the Go-stdlib-CVE-patched 2.11.4 rebuild"
     command: "caddy"
     args: ["version"]
-    expectedOutput: ["v2.11.3.*"]
+    expectedOutput: ["v2.11.4.*"]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "web3-sample-app",
   "version": "v0.0.18",
   "private": true,
-  "packageManager": "pnpm@11.3.0",
+  "packageManager": "pnpm@11.8.0",
   "description": "Web3 frontend with React, Vite, TypeScript and viem 2",
   "license": "MIT",
   "author": "AndriyKalashnykov(AndriyKalashnykov@gmail.com)",
@@ -29,8 +29,8 @@
     "react-dom": "^19.2.7",
     "react-i18next": "^17.0.8",
     "react-redux": "^9.3.0",
-    "react-router-dom": "^7.17.0",
-    "viem": "^2.52.2"
+    "react-router-dom": "^7.18.0",
+    "viem": "^2.53.1"
   },
   "devDependencies": {
     "@playwright/test": "1.61.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,11 +42,11 @@ importers:
         specifier: ^9.3.0
         version: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
       react-router-dom:
-        specifier: ^7.17.0
-        version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^7.18.0
+        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       viem:
-        specifier: ^2.52.2
-        version: 2.52.2(typescript@6.0.3)
+        specifier: ^2.53.1
+        version: 2.53.1(typescript@6.0.3)
     devDependencies:
       '@playwright/test':
         specifier: 1.61.0
@@ -1253,15 +1253,15 @@ packages:
       redux:
         optional: true
 
-  react-router-dom@7.17.0:
-    resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
+  react-router-dom@7.18.0:
+    resolution: {integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.17.0:
-    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
+  react-router@7.18.0:
+    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -1420,8 +1420,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  viem@2.52.2:
-    resolution: {integrity: sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==}
+  viem@2.53.1:
+    resolution: {integrity: sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -2597,13 +2597,13 @@ snapshots:
       '@types/react': 19.2.17
       redux: 5.0.1
 
-  react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie: 1.1.1
       react: 19.2.7
@@ -2743,7 +2743,7 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  viem@2.52.2(typescript@6.0.3):
+  viem@2.53.1(typescript@6.0.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0

--- a/renovate.json
+++ b/renovate.json
@@ -79,14 +79,12 @@
       "description": "Group devDependencies non-major updates",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "dev-dependencies",
-      "automerge": true
+      "groupName": "dev-dependencies"
     },
     {
       "description": "Group type definitions",
       "matchPackageNames": ["/^@types\\//"],
-      "groupName": "type-definitions",
-      "automerge": true
+      "groupName": "type-definitions"
     },
     {
       "description": "Group Docker base images (Dockerfiles AND custom-regex docker-datasource pins like CLOUD_PROVIDER_KIND_VERSION / MERMAID_CLI_VERSION / KIND_NODE_IMAGE)",
@@ -110,6 +108,11 @@
       "matchManagers": ["mise", "npm"],
       "matchPackageNames": ["pnpm"],
       "groupName": "pnpm"
+    },
+    {
+      "description": "Group the Node version across managers. Node is mirrored in .mise.toml/.node-version (mise manager, datasource node-version, major 24) and in the node:NN FROM lines of Dockerfile/Dockerfile.prod (dockerfile manager, datasource docker, 24.16.0). Without this rule a Node bump opens independent PRs that can land separately and drift the pins (make check-node-alignment then reds CI). Placed LAST so this groupName wins for node over the Docker dependencies group.",
+      "matchDepNames": ["node"],
+      "groupName": "Node"
     }
   ]
 }


### PR DESCRIPTION
## Summary

`/ship-it` full pipeline: Stage 1 (upgrade-analysis) + Stage 2 (project-review), both applied and verified locally.

### Stage 1 — Upgrades
- **caddy 2.11.3 → 2.11.4** and **retired the go-jose `--replace` xcaddy workaround** (2.11.4 ships go-jose/v3 v3.0.5). Kept the `GOTOOLCHAIN=go1.26.4` rebuild — vanilla `caddy:2.11.4-alpine` still ships a Go 1.26.3 binary (stdlib CVE-2026-42504), verified via `trivy image`.
- **node 24.16.0 → 24.17.0** (both Dockerfiles, digest-pinned)
- **kind 0.31.0 → 0.32.0** + **KIND_NODE_IMAGE v1.35.1 → v1.36.1** (v1.35.1 was dropped from the 0.32 node-image catalog; v1.36.1 aligns with kubectl 1.36.x)
- **pnpm 11.3.0 → 11.8.0** (.mise.toml + `packageManager`)
- mise tool patches: act 0.2.89, kubectl 1.36.2, yq 4.53.3, **trivy 0.70.0 → 0.71.2**, renovate 43.235.1
- **react-router-dom 7.18.0**, **viem 2.53.1**
- `.trivyignore`: time-boxed waivers (`exp:2026-07-22`) for 3 base-image OS CVEs (`CVE-2026-45447` openssl / `CVE-2026-45186` libexpat / `CVE-2026-6732` libxml2) not yet fixed in the alpine 3.23 repo — reachability is nil (caddy is a static Go binary linking none of them). CI Trivy step's `.trivyignore` made explicit.

### Stage 2 — Project-review fixes
- **renovate**: add `Node` cross-manager group (mise + dockerfile) so a Node bump can't split into independent PRs; drop 2 redundant per-rule `automerge: true`.
- **cleanup-{runs,images}.yml**: `cancel-in-progress: false`.
- **README**: H1 → "Ethereum Balance Viewer — React SPA"; tighten `cosign verify` identity-regexp to the `ci.yml@refs/tags/v` form; add `container-structure-test`/`renovate`/host-prereq notes; trim C4Deployment diagram to ≤15 elements.
- **CLAUDE.md**: add `container-structure-test` to tool enumerations; fix Skills-table paths; refresh backlog + Dockerfile.prod description for the caddy 2.11.4 state.

## Test plan
- [x] `pnpm build` clean
- [x] `make test` 36/36
- [x] `make integration-test` 5/5 (real RPC)
- [x] `make static-check` rc=0 (node-alignment, lint, vulncheck, trivy-fs, trivy-config, secrets, mermaid-lint, deps-prune)
- [x] prod image: build + `trivy image` clean (with waivers) + `container-structure-test` 6/6
- [x] `make ci-run` (act): all real gates green; only `Upload SBOM` fails on the known act artifact-server limitation (works on real Actions)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)