### PR TITLE
chore: project-review fixes, test coverage, tag-only image build + e2e cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       # On tag pushes the diff against `main` may be empty (the tag points at
       # the same SHA), which would skip everything — force `code=true`.
       code: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.code }}
+      # Markdown changes gate a lightweight mermaid-lint job (README mermaid is
+      # docs-excluded from `code`, so static-check's mermaid-lint never sees it).
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -50,8 +53,26 @@ jobs:
           base: ${{ github.event_name == 'push' && 'main' || '' }}
           filters: |
             code:
-              - '!(**.md|docs/**|LICENSE|.gitignore|.claudeignore|.claude/**|**.png|**.jpg|**.gif|**.svg)'
+              - '!(**.md|docs/**|specs/**|benchmarks/**|LICENSE|.gitignore|.claudeignore|.claude/**|**.png|**.jpg|**.gif|**.svg)'
               - 'CLAUDE.md'
+            docs:
+              - '**.md'
+
+  mermaid-lint:
+    # README/docs mermaid blocks are docs-excluded from `code`, so a docs-only
+    # change skips static-check (which runs mermaid-lint). Gate the lint here for
+    # docs-only changes so a broken README diagram can't ship ungated. Code
+    # changes already run mermaid-lint inside static-check, so skip it there.
+    needs: [changes]
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.docs == 'true' && needs.changes.outputs.code != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Mermaid lint
+        run: make mermaid-lint
 
   static-check:
     needs: [changes]
@@ -127,9 +148,23 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' && vars.ACT != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Reuse cached prod-image layers across runs (and across make e2e +
+    # make e2e-browser) so the e2e job doesn't cold-build Dockerfile.prod each run.
+    env:
+      DOCKER_BUILD_CACHE: "--cache-from type=gha --cache-to type=gha,mode=max"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Exports ACTIONS_RUNTIME_TOKEN + ACTIONS_CACHE_URL so the Makefile's raw
+      # `docker buildx build --cache-to type=gha` (DOCKER_BUILD_CACHE) can reach the
+      # GitHub Actions cache. docker/build-push-action does this internally; a raw
+      # buildx invocation needs the runtime exported explicitly.
+      - name: Export Actions cache runtime
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
 
       - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -200,11 +235,14 @@ jobs:
           retention-days: 7
 
   docker:
-    # Pattern A: validate on every push (Gates 1-3 + linux/amd64 validation
-    # build), publish + sign only on tag pushes. Catches regressions before
-    # release day instead of on it.
+    # Build, scan, and publish the production image ONLY on tag pushes (releases
+    # — `make release` cuts a `vN.N.N` tag). On non-tag pushes this whole job is
+    # skipped, so no image is built/scanned/published on ordinary commits.
+    # NOTE: the Dockerfile is still exercised on every push by the `e2e` job
+    # (KinD deploy builds the prod image), so a broken Dockerfile is still caught
+    # pre-tag there — but the image SCAN / structure-test / SBOM only run on tags.
     needs: [changes, static-check, build, test]
-    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' }}
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -215,6 +253,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false   # job publishes to GHCR (OIDC/GITHUB_TOKEN), never pushes git
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -261,7 +301,7 @@ jobs:
       # GATE 2 — Trivy image scan (CRITICAL/HIGH blocking)
       # ===============================================================
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: web3-sample-app:scan
           scanners: 'vuln,secret,misconfig'
@@ -274,7 +314,7 @@ jobs:
       # GATE 2.5 — container structure test (USER, entrypoint, labels, files)
       # ===============================================================
       - name: Container structure test
-        run: container-structure-test test --image web3-sample-app:scan --config container-structure-test.yaml
+        run: make container-structure-test-only CST_IMAGE=web3-sample-app:scan
 
       # ===============================================================
       # GATE 2.7 — SBOM (SPDX) via Trivy. Generated as a separate artifact +
@@ -282,8 +322,8 @@ jobs:
       # would break the GHCR "OS / Arch" tab. Preserves the manifest UI while
       # still publishing a verifiable SBOM.
       # ===============================================================
-      - name: Generate SBOM (SPDX)
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+      - name: Generate SPDX SBOM
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: web3-sample-app:scan
           scan-type: image
@@ -291,6 +331,11 @@ jobs:
           output: sbom.spdx.json
 
       - name: Upload SBOM
+        # act's local artifact server speaks the v4 protocol; upload-artifact v7
+        # trips it (same reason the build-artifact upload is ACT-gated). The SBOM
+        # is consumed on real GHA only (cosign reads the workspace file directly,
+        # not the artifact), so skipping the upload under act is safe.
+        if: ${{ vars.ACT != 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-spdx
@@ -330,9 +375,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # On non-tag pushes this runs as a validation build (push: false) so
-      # build regressions surface before tag day. Single-arch (linux/amd64);
-      # arm64 dropped to keep CI fast (no QEMU cross-build).
+      # The job only runs on tag pushes, so this always publishes. Single-arch
+      # (linux/amd64); arm64 dropped to keep CI fast (no QEMU cross-build).
       - name: Build and push
         id: push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -340,7 +384,7 @@ jobs:
           context: .
           file: ./Dockerfile.prod
           platforms: linux/amd64
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          push: true
           provenance: false
           sbom: false
           tags: ${{ steps.meta.outputs.tags }}
@@ -383,11 +427,12 @@ jobs:
           cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${repo}@${DIGEST}"
 
   dast:
-    # Runs in parallel with `docker`. Skipped under act because ZAP's docker-
-    # in-docker bind mount of $GITHUB_WORKSPACE/zap-output doesn't round-trip
-    # through act's host docker daemon. `make ci-run` passes --var ACT=true.
+    # Tag-push only (mirrors `docker`): builds the prod image + runs the OWASP ZAP
+    # baseline at release, not on every commit. Also skipped under act because
+    # ZAP's docker-in-docker bind mount of $GITHUB_WORKSPACE/zap-output doesn't
+    # round-trip through act's host docker daemon. `make ci-run` passes --var ACT=true.
     needs: [changes, build, test]
-    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' && vars.ACT != 'true' }}
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' && vars.ACT != 'true' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -397,7 +442,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -464,7 +509,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, static-check, build, test, integration-test, e2e, dast, docker]
+    needs: [changes, mermaid-lint, static-check, build, test, integration-test, e2e, dast, docker]
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: write
+      pull-requests: read   # exclude open-PR head SHAs from deletion (make cleanup-runs)
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.mise.toml
+++ b/.mise.toml
@@ -39,8 +39,10 @@ pnpm = "11.8.0"
 # Tracked: github-tags github.com/GoogleContainerTools/container-structure-test
 "aqua:GoogleContainerTools/container-structure-test" = "1.22.1"
 
-# Tracked: npm registry (renovate package).
-"npm:renovate" = "43.235.1"
+# Note: the Renovate CLI itself is intentionally NOT pinned here. It lives as the
+# RENOVATE_VERSION Makefile constant (npm datasource, fetched on demand via
+# `mise exec`) so `mise install` does not eagerly reinstall its ~600-package npm
+# tree on every `make deps`. See Makefile + renovate.json (matchDepNames:renovate).
 
 # Note: cloud-provider-kind runs as a Docker container (registry.k8s.io/...)
 # pinned via CLOUD_PROVIDER_KIND_VERSION in the Makefile + Renovate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 All commands go through the Makefile. Use `make help` to list targets.
 
 ```bash
-make deps           # install mise + all pinned tools (node, pnpm, hadolint, kubectl, kind, yq, trivy, gitleaks, act, container-structure-test, renovate)
+make deps           # install mise + all pinned tools (node, pnpm, hadolint, kubectl, kind, yq, trivy, gitleaks, act, container-structure-test)
 make install        # pnpm install (uses --frozen-lockfile when CI=true)
 make build          # tsc + vite build (depends on install)
 make lint           # prettier --check + hadolint
@@ -40,7 +40,9 @@ make cleanup-images # delete untagged GHCR images, keep 5 (called by cleanup-ima
 
 ## Tool Versions (mise)
 
-`.mise.toml` is the single source of truth for every pinned tool: Node.js, pnpm, hadolint, kubectl, kind, yq, Trivy, gitleaks, act, container-structure-test, and `npm:renovate`. `make deps` bootstraps mise via `https://mise.run` (installs to `~/.local/bin`, no sudo) and then runs `mise install` to provision the rest. CI uses `jdx/mise-action` so local and CI read the same `.mise.toml`. Renovate tracks updates via the native `mise` manager.
+`.mise.toml` is the single source of truth for every pinned tool: Node.js, pnpm, hadolint, kubectl, kind, yq, Trivy, gitleaks, act, container-structure-test. `make deps` bootstraps mise via `https://mise.run` (installs to `~/.local/bin`, no sudo) and then runs `mise install` to provision the rest. CI uses `jdx/mise-action` so local and CI read the same `.mise.toml`. Renovate tracks updates via the native `mise` manager.
+
+The Renovate CLI itself is deliberately **not** in `.mise.toml` — it is pinned as the `RENOVATE_VERSION` Makefile constant (`# renovate: datasource=npm depName=renovate`) and fetched on demand by `make renovate-validate` via `mise exec`, so `mise install` does not eagerly reinstall renovate's ~600-package npm tree on every `make deps`. Its near-daily self-bump is throttled to weekly in `renovate.json` (`matchDepNames:["renovate"]`).
 
 Three Docker-image versions stay pinned as Makefile constants (with `# renovate:` annotations) because mise can't manage Docker images: `MERMAID_CLI_VERSION` (mermaid lint), `ZAP_VERSION` (DAST), `CLOUD_PROVIDER_KIND_VERSION` (KinD LoadBalancer controller). `KIND_NODE_IMAGE` is also a Makefile constant but is bumped together with the `aqua:kubernetes-sigs/kind` mise pin (see KinD release notes for matched node image — not independently trackable).
 
@@ -53,7 +55,7 @@ Four-layer test pyramid. Each layer has its own Makefile target, vitest/Playwrig
 | Unit + Component | `make test` | `vitest.config.ts` (excludes `**/*.integration.test.*`) | `src/store/models/__tests__/`, `src/service/ether/__tests__/ether.test.ts`, `src/components/__tests__/` | ~1s | Pure functions, Redux slices, mocked ether service, components rendered via `renderWithProviders` |
 | Integration | `make integration-test` | `vitest.integration.config.ts` (`include: ['**/*.integration.test.ts']`, 30s timeout, node env) | `src/service/ether/__tests__/ether.integration.test.ts` | ~5s | Ether service against the real `VITE_RPCENDPOINT` (block fetch, ETH/DAI balance, malformed-input negative paths) |
 | E2E (curl) | `make e2e` | `e2e/e2e-test.sh` | KinD + cloud-provider-kind LoadBalancer (kind Docker network IP) | ~30s | Caddy routes (`/internal/isalive`, `/internal/isready`, `/publicnode` → 307, SPA fallback, missing asset 404) + verifies `start-caddy.sh` substituted `VITE_RPCENDPOINT` into `/config.js` (also runs `make e2e-browser` in CI — Playwright Chromium against deployed SPA, asserts real RPC roundtrip updates block counter) |
-| E2E (browser) | `make e2e-browser` | `e2e/playwright.config.ts` + `e2e/account-form.spec.ts` | KinD + cloud-provider-kind + Playwright Chromium | ~45s | AccountForm renders, real RPC roundtrip updates the displayed block number |
+| E2E (browser) | `make e2e-browser` | `e2e/playwright.config.ts` + `e2e/account-form.spec.ts` | KinD + cloud-provider-kind + Playwright Chromium | ~45s | AccountForm renders; real ETH + DAI RPC roundtrips update the block counter AND render a well-formed numeric balance; an `@axe-core/playwright` scan asserts no critical/serious WCAG2A/AA a11y violations |
 
 Notes:
 - `make test` and `make integration-test` are independent — the `test` job runs unit + component (no network), `integration-test` job runs the real-RPC suite (needs outbound HTTPS).
@@ -98,29 +100,29 @@ Vite (oxc minifier, not terser). Console and debugger statements are stripped in
 
 ## CI/CD
 
-- **ci.yml** job DAG: `changes` → `static-check` → (`test`, `integration-test`, `build` parallel) → (`e2e`, `dast`, `docker` parallel) → `ci-pass` (aggregator).
-  - `changes`: job-level path filter via `dorny/paths-filter`. Doc-only diffs (`**.md` outside `CLAUDE.md`, `docs/**`, `LICENSE`, `**.png`, etc.) set `outputs.code = false` → every heavy job short-circuits via `if: needs.changes.outputs.code == 'true'`. Tag pushes force `code = true` to avoid the empty-diff escape hatch. The workflow itself always runs so `ci-pass` always reports a status — Repository-Rulesets-safe.
+- **ci.yml** job DAG: `changes` → `static-check` → (`test`, `integration-test`, `build` parallel) → (`e2e`, `dast`, `docker` parallel) → `ci-pass` (aggregator). A lightweight `mermaid-lint` job also runs off `changes` for **docs-only** changes — README mermaid blocks are docs-excluded from `code`, so `static-check`'s mermaid-lint never sees them; on code changes `static-check` covers mermaid instead, so the job is gated `docs == 'true' && code != 'true'`.
+  - `changes`: job-level path filter via `dorny/paths-filter`. Doc-only diffs (`**.md` outside `CLAUDE.md`, `docs/**`, `specs/**`, `benchmarks/**`, `LICENSE`, `**.png`, etc.) set `outputs.code = false` → every heavy job short-circuits via `if: needs.changes.outputs.code == 'true'`. A second `outputs.docs` (any `**.md`) gates the `mermaid-lint` job. Tag pushes force `code = true` to avoid the empty-diff escape hatch. The workflow itself always runs so `ci-pass` always reports a status — Repository-Rulesets-safe.
   - `static-check`: composite of lint + vulncheck + trivy-fs + trivy-config + secrets + mermaid-lint + deps-prune-check via `make static-check`.
   - `integration-test`: real-RPC vitest suite (`make integration-test`).
   - `e2e`: KinD + `cloud-provider-kind` (real LoadBalancer Service IPs on the kind Docker network) + `make e2e` (curl) + `make e2e-browser` (Playwright Chromium). Gated `if: vars.ACT != 'true'`.
-  - `dast`: parallel with `docker`/`e2e`. Builds `:scan` image via shared cache, boots it, runs OWASP ZAP baseline (`-I`, FAIL-only blocking). Cached ZAP image (~3.4GB). Gated `if: vars.ACT != 'true'`. Uploads HTML/JSON/MD report.
-  - `docker`: Pattern A. Validation gates (Trivy image scan, smoke test, image build) run on **every push**; publish + cosign sign-by-digest are step-level gated to tag pushes only — catches build / signing regressions before tag day instead of on it.
+  - `dast`: **tag-push only** (mirrors `docker` — `startsWith(github.ref, 'refs/tags/')`). Builds `:scan` image via shared cache, boots it, runs OWASP ZAP baseline (`-I`, FAIL-only blocking) at release. Cached ZAP image (~3.4GB). Also gated `if: vars.ACT != 'true'`. Uploads HTML/JSON/MD report. (Moved off every-push to keep ordinary commits cheap; the image is scanned for CVEs by `docker`'s Trivy gate at the same release.)
+  - `docker`: **tag-push only** (job-level `if: … && startsWith(github.ref, 'refs/tags/')`). Build, Trivy image scan, container-structure-test, SBOM, smoke test, publish, and cosign sign-by-digest all run **only on release tags** (`make release` cuts a `vN.N.N` tag) — no image is built/scanned on ordinary commits. The Dockerfile is still compiled on every push by the `e2e` job (KinD deploy builds the prod image), so a broken Dockerfile is caught pre-tag there; only the image scan / structure-test / SBOM / publish are tag-gated.
     - Gate 1: Build for scan (`load: true`, linux/amd64) into local docker daemon
     - Gate 2: Trivy image scan (`CRITICAL,HIGH` blocking, `vuln,secret,misconfig` scanners)
-    - Gate 2.5: container-structure-test (`make container-structure-test` config — USER 1000, entrypoint, OCI labels, runtime files, CVE-patched caddy version)
+    - Gate 2.5: container-structure-test (`make container-structure-test-only CST_IMAGE=web3-sample-app:scan` — reuses the scan image; single-sources the command + `container-structure-test.yaml` config; USER 1000, entrypoint, OCI labels, runtime files, CVE-patched caddy version)
     - Gate 2.7: SPDX SBOM via Trivy → uploaded as the `sbom-spdx` artifact (and cosign-attested by digest on tag push). Kept out of the buildx manifest (`sbom: false`) so the GHCR "OS / Arch" tab still renders
     - Gate 3: Smoke test (`docker run` + `curl /internal/isalive`)
-    - Build (push: ${{ tag }}): single-arch (`linux/amd64`; arm64 dropped to keep CI fast), `provenance: false` + `sbom: false` (keeps GHCR "OS / Arch" tab rendering)
+    - Build + push (`push: true` — the job only runs on tags): single-arch (`linux/amd64`; arm64 dropped to keep CI fast), `provenance: false` + `sbom: false` (keeps GHCR "OS / Arch" tab rendering)
     - Cosign keyless OIDC signing by digest on tag push + SPDX SBOM attestation (requires `id-token: write`)
   - `ci-pass`: aggregator gate. Fails if any upstream job failed OR was cancelled.
-- All tools (Node, pnpm, hadolint, kubectl, kind, yq, Trivy, gitleaks, act, **renovate**) come from `.mise.toml` via `jdx/mise-action`. `cloud-provider-kind` runs as a Docker container pinned via `CLOUD_PROVIDER_KIND_VERSION` Makefile constant. `ZAP_VERSION` is duplicated between Makefile and workflow `env:` block; both annotations are tracked by Renovate's workflow custom-regex manager so they bump in lockstep.
+- All tools (Node, pnpm, hadolint, kubectl, kind, yq, Trivy, gitleaks, act) come from `.mise.toml` via `jdx/mise-action`. (The Renovate CLI is the `RENOVATE_VERSION` Makefile pin, fetched lazily via `mise exec` — see Tool Versions.) `cloud-provider-kind` runs as a Docker container pinned via `CLOUD_PROVIDER_KIND_VERSION` Makefile constant. `ZAP_VERSION` is duplicated between Makefile and workflow `env:` block; both annotations are tracked by Renovate's workflow custom-regex manager so they bump in lockstep.
 - **cleanup-runs.yml**: Weekly cleanup — `make cleanup-runs` (workflow runs > 7d) + `make cleanup-caches` (caches from merged or deleted branches).
 - **cleanup-images.yml**: Weekly cleanup of untagged GHCR images (`make cleanup-images`).
-- All GitHub Actions pinned to commit SHAs. Renovate manages dependency updates with platform automerge enabled (major updates delayed 3 days).
+- All GitHub Actions pinned to commit SHAs. Renovate manages dependency updates with PR automerge on green CI (`platformAutomerge: false` — race-safe for the required `ci-pass` check; major updates delayed 3 days).
 
 ## Image Publishing & Hardening
 
-The `docker` job in `ci.yml` ships images on tag pushes; on non-tag pushes it runs the same Trivy + smoke + `linux/amd64` validation build with `push: false`. See README "Pre-push image hardening" for the user-facing gate table and `cosign verify` command. To re-harden / extend, run `/harden-image-pipeline`.
+The `docker` job in `ci.yml` builds, scans, and ships images **on tag pushes only** (the whole job is gated `startsWith(github.ref, 'refs/tags/')`). See README "Release image hardening" for the user-facing gate table and `cosign verify` command. To re-harden / extend, run `/harden-image-pipeline`.
 
 `make ci-run-tag` exercises the `docker` job locally under act (synthetic tag-push event); cosign signing fails under act (no OIDC) — expected.
 
@@ -132,13 +134,13 @@ The `docker` job in `ci.yml` ships images on tag pushes; on non-tag pushes it ru
 - **`.dockerignore`**: Excludes `node_modules`, `dist`, `.git`, `e2e`, `zap-output`, `playwright-report`, `test-results`, `.env`.
 - **`.env.example`**: Committed source of truth for operator-tunable values (`VITE_RPCENDPOINT`, `APP_INTERNAL_PORT`, e2e/Make timeouts). Copy to gitignored `.env` to override locally; shell scripts source it, the Makefile mirrors it as `?=` defaults.
 - **`.hadolint.yaml`**: Configures hadolint rule ignores for Dockerfile linting.
-- **`caddy/Caddyfile`**: `admin off` / `auto_https off` / `persist_config off` (no writable state dirs); a single `header { defer … }` block applies CSP + X-Frame-Options + X-Content-Type-Options + Referrer-Policy + COOP/CORP + Permissions-Policy to every response; `handle /assets/*` returns 404 for missing assets (never SPA-fallback) with `Cache-Control: public, max-age=31536000, immutable`; `handle /config.js` adds `Cache-Control: no-store`; `handle /publicnode` is a 307 redirect to `{$PUBLIC_RPC_URL:…}` (env-driven, defaults to the public node); the server listens on `:{$PORT:8080}` (ConfigMap-driven); `handle /internal/{isalive,isready}` use `respond` + `log_skip` (no access-log noise); the catch-all `handle` does `try_files {path} /index.html` for SPA fallback.
+- **`caddy/Caddyfile`**: `admin off` / `auto_https off` / `persist_config off` (no writable state dirs); a single `header { defer … }` block applies CSP + X-Frame-Options + X-Content-Type-Options + Referrer-Policy + COOP/CORP + Permissions-Policy to every response; `handle /assets/*` returns 404 for missing assets (never SPA-fallback) with `Cache-Control: public, max-age=31536000, immutable`; `handle /config.js` adds `Cache-Control: no-store`; `handle /publicnode` is a 307 redirect to `{$PUBLIC_RPC_URL:…}` (env-driven, defaults to the public node); the server listens on `:{$PORT:8080}` (ConfigMap-driven); `handle /internal/{isalive,isready}` use `respond` + `log_skip` (no access-log noise); the catch-all `handle` does `try_files {path} /index.html` for SPA fallback. **By design**, the CSP allows a `connect-src https:` wildcard (keeps `VITE_RPCENDPOINT` runtime-configurable) and omits COEP (it would block the cross-origin RPC fetch); the resulting ZAP `WARN-NEW` advisories are intentional, not findings — the DAST gate is FAIL-only (`FAIL-NEW: 0`).
 - Both Dockerfiles use `pnpm install --frozen-lockfile` and copy lockfiles before source for layer caching.
 
 ## Conventions
 
 - Package manager: **pnpm only** (no `npm`, no `npx` — Makefile uses `pnpm dlx`; Dockerfiles use `corepack enable pnpm`; `packageManager` field in package.json).
-- Tool versioning: **mise** via `.mise.toml` (single source of truth across local + CI). Includes `npm:renovate`, `aqua:` pins for kubectl/kind/yq/hadolint/act/trivy/gitleaks. Docker-image tools (`MERMAID_CLI_VERSION`, `ZAP_VERSION`, `CLOUD_PROVIDER_KIND_VERSION`) stay as Makefile constants (Renovate-tracked) since mise can't manage Docker images directly. `KIND_NODE_IMAGE` is also a Makefile constant but bumped together with `aqua:kubernetes-sigs/kind` per KinD release notes.
+- Tool versioning: **mise** via `.mise.toml` (single source of truth across local + CI). Includes `aqua:` pins for kubectl/kind/yq/hadolint/act/trivy/gitleaks plus core node/pnpm. The Renovate CLI is pinned separately as `RENOVATE_VERSION` in the Makefile (npm datasource, fetched lazily via `mise exec`) so `make deps` doesn't eagerly reinstall its large dependency tree. Docker-image tools (`MERMAID_CLI_VERSION`, `ZAP_VERSION`, `CLOUD_PROVIDER_KIND_VERSION`) stay as Makefile constants (Renovate-tracked) since mise can't manage Docker images directly. `KIND_NODE_IMAGE` is also a Makefile constant but bumped together with `aqua:kubernetes-sigs/kind` per KinD release notes.
 - Multi-session safety: `KIND_CLUSTER_NAME := $(APP_NAME)` and every `kubectl` invocation goes through `KUBECTL := kubectl --context=kind-$(KIND_CLUSTER_NAME)` so a parallel `make` from a sibling KinD project can't silently steer recipes to the wrong cluster.
 - Node.js: pinned in `.mise.toml` (currently `node = "24"`); `.node-version` mirrors the major (`24`) and both Dockerfiles pin `node:24.x`. `make check-node-alignment` (first prerequisite of `static-check`) fails the build if any of these drift, and a Renovate cross-manager group bumps the mise + Dockerfile pins together.
 - TypeScript: **6.x** with `moduleResolution: "bundler"` (no `baseUrl`, no `esModuleInterop`).
@@ -155,7 +157,6 @@ Last reviewed: 2026-06-22 (`/ship-it` follow-up — `@types/node` 25→26 (tsc +
 
 - [ ] **Architecture diagram tech-strings drift** — README's C4 diagrams embed framework version strings (e.g. `"React 19 SPA, viem 2"`, `"Caddy 2 on :8080"`). Renovate cannot update these. Re-run `/architecture-diagrams` after any major bump.
 - [ ] **`.trivyignore` waivers for 3 base-image OS CVEs** — `CVE-2026-45447` (openssl), `CVE-2026-45186` (libexpat), `CVE-2026-6732` (libxml2) are present in the `caddy:2.11.4-alpine`/alpine-3.23 base; fixes are not yet in the alpine 3.23 repo (`apk upgrade` has no newer package), so they're waived with `exp:2026-07-22`. Reachability is nil (caddy is a static Go binary linking none of them). The Dockerfile's `apk --no-cache upgrade` pulls the fixes automatically once alpine ships them — remove the `.trivyignore` entries when `apk upgrade --simulate` shows the patched versions, or the waivers auto-expire on 2026-07-22 (re-evaluate then).
-- The ZAP `WARN-NEW` DAST advisories (CSP `connect-src https:` wildcard, missing COEP) are **intentional, documented design** in `caddy/Caddyfile` — the wildcard keeps `VITE_RPCENDPOINT` runtime-configurable and COEP would block the cross-origin RPC fetch. Not findings; left by design (the DAST gate is FAIL-only, `FAIL-NEW: 0`).
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,13 @@ ZAP_VERSION := 2.17.0
 # renovate: datasource=docker depName=registry.k8s.io/cloud-provider-kind/cloud-controller-manager
 CLOUD_PROVIDER_KIND_VERSION := v0.10.0
 
+# Renovate CLI version — pinned HERE (not in .mise.toml) so `mise install` does
+# not eagerly reinstall renovate's ~600-package npm tree on every `make deps`.
+# `renovate-validate` fetches it on demand via `mise exec`. Self-bump throttled
+# to weekly in renovate.json (matchDepNames:["renovate"]).
+# renovate: datasource=npm depName=renovate
+RENOVATE_VERSION := 43.235.1
+
 KIND_CLUSTER_NAME := $(APP_NAME)
 K8S_NAMESPACE     := web3
 
@@ -98,6 +105,11 @@ deps-trivy: deps
 #deps-secrets: @ (alias for deps) Install gitleaks for secret scanning
 deps-secrets: deps
 
+# Internal guard: fail fast with a clear message when Docker (a host prerequisite,
+# not mise-managed) is missing. Wired as a prerequisite to docker-using targets.
+_require-docker:
+	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for this target. Install Docker: https://docs.docker.com/get-docker/"; exit 1; }
+
 #clean: @ Cleanup build artifacts
 clean:
 	@rm -rf node_modules/ dist/ zap-output/ e2e/playwright-report/ e2e/test-results/
@@ -142,7 +154,7 @@ secrets: deps-secrets
 	@gitleaks detect --no-banner --redact --source .
 
 #mermaid-lint: @ Validate Mermaid blocks in markdown files via official CLI
-mermaid-lint:
+mermaid-lint: _require-docker
 	@set -euo pipefail; \
 	IMAGE="minlag/mermaid-cli:$(MERMAID_CLI_VERSION)"; \
 	for attempt in 1 2 3; do \
@@ -246,12 +258,19 @@ run: install
 	@pnpm dev
 
 #image-build: @ Build a dev Docker image
-image-build:
+image-build: _require-docker
 	@docker buildx build --load -t $(APP_NAME):$(CURRENTTAG) .
 
+# Optional buildx cache flags. EMPTY by default so local builds use the plain
+# docker driver (no gha backend, no behavior change). CI's e2e job sets this to
+# `--cache-from type=gha --cache-to type=gha,mode=max` (with setup-buildx-action +
+# the exported runtime tokens) so the prod-image build reuses cached layers across
+# runs AND across `make e2e` + `make e2e-browser` in the same job.
+DOCKER_BUILD_CACHE ?=
+
 #image-build-prod: @ Build a production Docker image (Dockerfile.prod)
-image-build-prod:
-	@docker buildx build --load -t $(APP_NAME):$(CURRENTTAG) -f Dockerfile.prod .
+image-build-prod: _require-docker
+	@docker buildx build --load $(DOCKER_BUILD_CACHE) -t $(APP_NAME):$(CURRENTTAG) -f Dockerfile.prod .
 
 #image-run: @ Run the locally-built image on port 8080
 image-run: image-stop
@@ -261,9 +280,17 @@ image-run: image-stop
 image-stop:
 	@docker stop $(APP_NAME) || true
 
-#container-structure-test: @ Validate prod image structure (USER, entrypoint, labels, files, caddy version)
-container-structure-test: deps image-build-prod
-	@container-structure-test test --image $(APP_NAME):$(CURRENTTAG) --config container-structure-test.yaml
+# Image validated by container-structure-test. Defaults to the locally-built tag;
+# CI overrides with CST_IMAGE=web3-sample-app:scan to reuse the already-built
+# scan image (so the command + config are single-sourced here, no CI drift).
+CST_IMAGE ?= $(APP_NAME):$(CURRENTTAG)
+
+#container-structure-test: @ Build prod image then validate its structure (USER, entrypoint, labels, files, caddy version)
+container-structure-test: deps image-build-prod container-structure-test-only
+
+#container-structure-test-only: @ Validate an already-built image's structure (override CST_IMAGE; CI calls this against the scan image)
+container-structure-test-only: _require-docker
+	@container-structure-test test --image $(CST_IMAGE) --config container-structure-test.yaml
 
 #docker-smoke-test: @ Build prod image, run it on 8080, probe /internal/isalive (mirrors CI Gate 3)
 docker-smoke-test: image-build-prod
@@ -284,7 +311,7 @@ docker-smoke-test: image-build-prod
 	echo "PASS: $(APP_NAME) container booted Caddy successfully"
 
 #dast-scan: @ Run OWASP ZAP baseline against an already-running smoke container on :8080 (CI gate)
-dast-scan:
+dast-scan: _require-docker
 	@mkdir -p zap-output && chmod 777 zap-output
 	@docker run --rm --network host \
 		-v "$(PWD)/zap-output:/zap/wrk:rw" \
@@ -457,14 +484,19 @@ deps-prune-check: install
 		exit 1; \
 	fi
 
-#renovate-validate: @ Validate Renovate configuration (renovate provided by mise via npm:renovate)
+#renovate-validate: @ Validate Renovate configuration (renovate fetched on demand via mise exec, not eagerly installed)
 renovate-validate: deps
-	@renovate --platform=local
+	@mise exec "npm:renovate@$(RENOVATE_VERSION)" -- renovate --platform=local
 
-#cleanup-runs: @ Delete workflow runs older than 7 days (keeps at least 5)
+#cleanup-runs: @ Delete workflow runs older than 7 days (keeps newest 5 PER workflow; never deletes open-PR runs)
 cleanup-runs:
-	@gh run list --limit 100 --json databaseId,createdAt,status \
-		--jq '[.[] | select(.createdAt < (now - 7*24*3600 | strftime("%Y-%m-%dT%H:%M:%SZ")))] | sort_by(.createdAt) | reverse | .[5:] | .[].databaseId' \
+	@set -euo pipefail; \
+	KEEP=5; \
+	CUTOFF=$$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ); \
+	OPEN_SHAS=$$(gh pr list --state open --json headRefOid --jq '[.[].headRefOid]' 2>/dev/null || echo '[]'); \
+	[ -n "$$OPEN_SHAS" ] || OPEN_SHAS='[]'; \
+	gh run list --limit 300 --json databaseId,createdAt,workflowName,headSha \
+		| jq -r --argjson keep "$$KEEP" --arg cutoff "$$CUTOFF" --argjson open "$$OPEN_SHAS" 'group_by(.workflowName) | map(sort_by(.createdAt) | reverse | .[$$keep:][]) | .[] | select(.createdAt < $$cutoff and (.headSha as $$s | ($$open | index($$s)) | not)) | .databaseId' \
 	| while read -r run_id; do \
 		echo "Deleting run $$run_id"; \
 		gh run delete "$$run_id" || true; \
@@ -496,7 +528,7 @@ cleanup-images:
 .PHONY: help deps deps-act deps-hadolint deps-k8s deps-trivy deps-secrets deps-playwright clean install build lint vulncheck \
 	trivy-fs trivy-config secrets mermaid-lint check-node-alignment static-check format check upgrade \
 	test test-watch test-coverage integration-test e2e e2e-browser run \
-	image-build image-build-prod image-run image-stop docker-smoke-test container-structure-test dast dast-scan \
+	image-build image-build-prod image-run image-stop docker-smoke-test container-structure-test container-structure-test-only dast dast-scan _require-docker \
 	ci ci-run ci-run-tag release tag-delete \
 	kind-up kind-down kind-create kind-destroy kind-cloud-provider-start kind-cloud-provider-stop \
 	kind-deploy kind-undeploy kind-redeploy deps-prune deps-prune-check renovate-validate \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ C4Context
 | Testing | Vitest 4, React Testing Library, jsdom, Playwright (Chromium) |
 | Container | Builder: `node:24.17.0-alpine`; runtime: `caddy:2.11.4-alpine` (port 8080, runs as UID 1000; `cap_net_bind_service` stripped from the binary so it execs cleanly under `securityContext.capabilities.drop:[ALL]`) |
 | Orchestration | Kubernetes (manifests under `k8s/`); local KinD via Makefile |
-| CI/CD | GitHub Actions, Renovate (platform automerge) |
+| CI/CD | GitHub Actions, Renovate (PR automerge on green CI) |
 | Code quality | Prettier, hadolint, Trivy (fs+config), gitleaks |
 | Tool versioning | mise (single source of truth in `.mise.toml`) |
 
@@ -334,8 +334,8 @@ GitHub Actions runs on every push to `main`, every tag `v*`, every pull request,
 | **integration-test** | after static-check | `make integration-test` (real-RPC integration suite) |
 | **build** | after static-check | `make build`; uploads `dist/` artifact |
 | **e2e** | after build + test (skipped under act) | KinD + cloud-provider-kind LoadBalancer + curl assertions + Playwright browser e2e — `make e2e` and `make e2e-browser` |
-| **dast** | after build + test (skipped under act) | OWASP ZAP baseline scan against booted container; ZAP image cached |
-| **docker** | after static-check + build + test | Validates Trivy image scan + container-structure-test + SPDX SBOM + smoke test + `linux/amd64` build on every push; pushes to GHCR + cosign keyless signing + SBOM attestation only on tag push |
+| **dast** | tag pushes only (after build + test; skipped under act) | OWASP ZAP baseline scan against booted container at release; ZAP image cached |
+| **docker** | tag pushes only (after static-check + build + test) | Builds + Trivy image scan + container-structure-test + SPDX SBOM + smoke test + `linux/amd64` build + push to GHCR + cosign keyless signing + SBOM attestation — all gated to release tags (`v*`). No image is built on ordinary commits |
 | **ci-pass** | always (after all above) | Aggregator gate; fails if any upstream job failed or was cancelled |
 
 #### Required Secrets and Variables
@@ -348,9 +348,9 @@ GitHub Actions runs on every push to `main`, every tag `v*`, every pull request,
 | `vars.HEALTHCHECK_HOST` | Variable (optional) | `docker`, `dast` | Overrides the host the smoke/DAST probe targets. Defaults to `localhost` |
 | `secrets.GITHUB_TOKEN` | Secret (auto) | `docker`, cleanup workflows | Provided by GitHub Actions; used to push to GHCR and call the API |
 
-### Pre-push image hardening
+### Release image hardening
 
-The `docker` job runs the following gates **before** any image is pushed to GHCR. Any failure blocks the release.
+On a release tag (`v*`), the `docker` job runs the following gates in order **before** the image is pushed to GHCR. Any failure blocks the publish. (On ordinary commits this job is skipped — no image is built.)
 
 | # | Gate | Catches | Tool |
 |---|------|---------|------|
@@ -362,7 +362,7 @@ The `docker` job runs the following gates **before** any image is pushed to GHCR
 | 4 | Build + push (`linux/amd64`) | Publishes the image with `cache-from: type=gha` (~95% cache hit from Gate 1) | `docker/build-push-action` |
 | 5 | **Cosign keyless OIDC signing** | Sigstore signature on the manifest digest (Rekor transparency log) | `sigstore/cosign-installer` + `cosign sign --yes <tag>@<digest>` |
 
-The parallel `dast` job adds:
+The `dast` job (also tag-push only) adds:
 
 | Gate | Catches | Tool |
 |------|---------|------|
@@ -397,7 +397,7 @@ Uses [act](https://github.com/nektos/act) with a randomized artifact-server port
 
 ### Dependency management
 
-[Renovate](https://docs.renovatebot.com/) manages dependency updates with platform automerge enabled. Updates automerge after CI passes; major updates wait 3 days for stability. Tool versions in `.mise.toml` are tracked by Renovate's `mise` manager (and the `# renovate:` inline annotations on aqua: pins).
+[Renovate](https://docs.renovatebot.com/) manages dependency updates with PR automerge. Updates merge automatically once the required `ci-pass` check is green — platform automerge is intentionally **off** (`platformAutomerge: false`), so Renovate merges via its own run after re-confirming the check rather than racing GitHub's native auto-merge before the check registers. Major updates wait 3 days for stability. Tool versions in `.mise.toml` are tracked by Renovate's `mise` manager (and the `# renovate:` inline annotations on aqua: pins).
 
 ## Release
 
@@ -411,3 +411,11 @@ Uses [act](https://github.com/nektos/act) with a randomized artifact-server port
    ```bash
    make tag-delete TAG=v0.0.1
    ```
+
+## Contributing
+
+Contributions are welcome. Open an issue to discuss a change, or send a pull request — CI (`make ci`) must pass before merge.
+
+## License
+
+Released under the [MIT License](./LICENSE).

--- a/e2e/account-form.spec.ts
+++ b/e2e/account-form.spec.ts
@@ -1,6 +1,40 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
 
 const TEST_ADDRESS = '0xeB2629a2734e272Bcc07BDA959863f316F4bD4Cf'
+
+// Poll the rendered "Last Block: <n>" until it updates from 0 to a real block
+// height. The callback is wrapped in try/catch: an in-flight React re-render
+// (the form disables/re-enables during the async query) can detach the node
+// mid-`innerText`, which `expect.poll` treats as a HARD failure rather than a
+// retry — returning 0 on a throw keeps it polling. (rules/common/testing.md)
+async function pollBlockGreaterThanZero(page: Page) {
+  await expect
+    .poll(
+      async () => {
+        try {
+          const text = await page.getByText(/Last Block:/).innerText()
+          const match = text.match(/Last Block:\s*(\d+)/)
+          return match ? Number(match[1]) : 0
+        } catch {
+          return 0
+        }
+      },
+      { timeout: 30_000, intervals: [500, 1000, 2000] },
+    )
+    .toBeGreaterThan(0)
+}
+
+// After a query lands (block > 0), the "Balance: <value>" line must render a
+// well-formed non-negative decimal — NOT just any non-empty text. This catches a
+// format/ABI regression (formatEther/formatUnits change, DAI ABI/contract drift)
+// that returns a block but garbage balance ("NaN", "undefined", "[object Object]").
+async function expectBalanceIsNumeric(page: Page) {
+  const text = await page.getByText(/Balance:/).innerText()
+  const match = text.match(/Balance:\s*([0-9]+(?:\.[0-9]+)?)\b/)
+  expect(match, `Balance line "${text}" is not a plain decimal`).not.toBeNull()
+  expect(Number(match![1])).toBeGreaterThanOrEqual(0)
+}
 
 test.describe('Web3 Sample App — AccountForm', () => {
   test('renders the SPA shell and AccountForm controls', async ({ page }) => {
@@ -28,18 +62,10 @@ test.describe('Web3 Sample App — AccountForm', () => {
 
     // Block counter must update from 0 to a real block height (>0). 30s budget
     // covers cold RPC latency without masking a real failure. Translation key
-    // `block` renders as "Last Block: <n>" (see src/locales/en.json) — match
-    // by the unique label suffix, not a `^block` anchor.
-    await expect
-      .poll(
-        async () => {
-          const text = await page.getByText(/Last Block:/).innerText()
-          const match = text.match(/Last Block:\s*(\d+)/)
-          return match ? Number(match[1]) : 0
-        },
-        { timeout: 30_000, intervals: [500, 1000, 2000] },
-      )
-      .toBeGreaterThan(0)
+    // `block` renders as "Last Block: <n>" (see src/locales/en.json).
+    await pollBlockGreaterThanZero(page)
+    // …and the Balance line must render a real numeric value, not just a block.
+    await expectBalanceIsNumeric(page)
   })
 
   test('queries a DAI balance via 3 contract reads and renders a numeric block', async ({
@@ -60,15 +86,32 @@ test.describe('Web3 Sample App — AccountForm', () => {
     await page.locator('input[placeholder]').first().fill(TEST_ADDRESS)
     await page.locator('#GetBalanceButton').click()
 
-    await expect
-      .poll(
-        async () => {
-          const text = await page.getByText(/Last Block:/).innerText()
-          const match = text.match(/Last Block:\s*(\d+)/)
-          return match ? Number(match[1]) : 0
-        },
-        { timeout: 30_000, intervals: [500, 1000, 2000] },
-      )
-      .toBeGreaterThan(0)
+    await pollBlockGreaterThanZero(page)
+    // The DAI balance line (formatUnits over the balanceOf read) must also render
+    // a well-formed number — a DAI-specific ABI/contract regression that returns
+    // a block but garbage balance is caught here, not just at the block counter.
+    await expectBalanceIsNumeric(page)
+  })
+
+  test('home page has no critical or serious accessibility violations (axe)', async ({
+    page,
+  }) => {
+    // Emulate reduced motion via emulateMedia (NOT config `use.reducedMotion`,
+    // which is shadowed by the `devices['Desktop Chrome']` use block) so axe
+    // reads settled colors, never mid-transition blends. (rules/common/testing.md)
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.goto('/')
+    await expect(page.locator('#root')).toBeVisible()
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa'])
+      .analyze()
+    const blocking = results.violations.filter(
+      (v) => v.impact === 'critical' || v.impact === 'serious',
+    )
+    expect(
+      blocking,
+      `axe critical/serious violations: ${JSON.stringify(blocking.map((v) => v.id))}`,
+    ).toEqual([])
   })
 })

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -213,7 +213,10 @@ assert_status GET "$BASE/assets/does-not-exist.js" 404
 # A real hashed asset must be 200 + immutable long-cache.
 assert_real_asset_cached
 
-# Public RPC redirect (Caddy /publicnode -> 307 to public RPC)
+# Public RPC redirect (Caddy /publicnode -> 307 to public RPC). The target is
+# env-driven (`{$PUBLIC_RPC_URL:…}` in the Caddyfile, set by the k8s ConfigMap).
+# This asserts the deployed default; to exercise the override path, deploy with a
+# distinct PUBLIC_RPC_URL in k8s/cm.yaml and re-run — the Location must follow it.
 assert_redirect_target "$BASE/publicnode" 307 "$EXPECTED_RPC_HOST"
 
 # Pattern C runtime config — VITE_RPCENDPOINT must be substituted into the
@@ -232,11 +235,12 @@ assert_config_var_substituted 'VITE_BASE_URL' "$VITE_BASE_URL"
 # loads it on every page render".
 assert_body_contains "$BASE/" '<script src="/config.js"></script>'
 
-# Security headers must reach the client on the SPA root AND on /config.js.
-# The Caddyfile's `header { defer ... }` sets these for every response, but a
-# future handler that calls `header` without `defer` could silently shadow
-# them — assert at the wire.
-for path in "/" "/config.js"; do
+# Security headers must reach the client on the SPA root, /config.js, AND on
+# /internal/* (whose `respond` handler could shadow the deferred set). The
+# Caddyfile's `header { defer ... }` sets these for every response, but a
+# future handler that calls `header`/`respond` without `defer` could silently
+# shadow them — assert at the wire on each handler that emits its own response.
+for path in "/" "/config.js" "/internal/isalive"; do
   assert_header_present "$BASE$path" 'Content-Security-Policy'    "default-src 'self'"
   assert_header_present "$BASE$path" 'X-Frame-Options'           'DENY'
   assert_header_present "$BASE$path" 'X-Content-Type-Options'    'nosniff'
@@ -248,10 +252,26 @@ for path in "/" "/config.js"; do
   assert_header_absent "$BASE$path" 'Server'
 done
 
+# /assets/* defines its OWN `header` block (immutable Cache-Control), the exact
+# shape that can silently shadow the global security-header set. Resolve a real
+# hashed asset and assert the security headers survive on it too.
+HEADER_ASSET=$(curl -sf "$BASE/" | grep -oE '/assets/[A-Za-z0-9._-]+\.js' | head -1 || true)
+if [[ -n "$HEADER_ASSET" ]]; then
+  assert_header_present "$BASE$HEADER_ASSET" 'Content-Security-Policy' "default-src 'self'"
+  assert_header_present "$BASE$HEADER_ASSET" 'X-Content-Type-Options'  'nosniff'
+else
+  echo "FAIL: could not resolve an /assets/*.js path for the header-shadow check"
+  FAIL=$((FAIL + 1))
+fi
+
 # /config.js must be served with Cache-Control: no-store so the browser
 # always re-fetches it on deploy — otherwise a stale runtime config sticks
 # until the user hard-reloads.
 assert_header_present "$BASE/config.js" 'Cache-Control' 'no-store'
+# /config.js is loaded as an external <script> under CSP `script-src 'self'`, so
+# the browser must receive a JavaScript MIME or it refuses to execute it (which
+# would break runtime config silently). Assert the Content-Type at the wire.
+assert_header_present "$BASE/config.js" 'Content-Type' '(text|application)/javascript'
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
   expect: { timeout: 15_000 },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
+  // retries:0 locally keeps the gate honest (a flaky test fails loudly). On CI we
+  // allow ONE retry ONLY because these tests hit a real external JSON-RPC
+  // (ethereum-rpc.publicnode.com) whose cold-start latency / transient rate-limit
+  // is genuine environmental jitter, not a product flake. A deterministic
+  // regression still fails both attempts.
   retries: process.env.CI ? 1 : 0,
   workers: 1,
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "viem": "^2.53.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "1.61.0",
     "@tailwindcss/postcss": "4.3.1",
     "@testing-library/jest-dom": "6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: ^2.53.1
         version: 2.53.1(typescript@6.0.3)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.61.0)
       '@playwright/test':
         specifier: 1.61.0
         version: 1.61.0
@@ -126,6 +129,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -792,6 +800,10 @@ packages:
 
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
@@ -1588,6 +1600,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.0)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.0
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -2208,6 +2225,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  axe-core@4.12.1: {}
 
   babel-plugin-macros@3.1.0:
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -127,6 +127,17 @@
       "description": "Group the caddy version across the Dockerfile.prod FROM digests (dockerfile manager, depName `caddy`) and the `xcaddy build vX.Y.Z` rebuild literal (custom.regex, depName `caddyserver/caddy`) so the rebuilt binary version never drifts from the runtime base. Placed LAST so this groupName wins for caddy over the Docker dependencies group; the FROM lines keep docker:pinDigests (only their datasource is docker), the xcaddy literal does not (github-releases).",
       "matchDepNames": ["caddy", "caddyserver/caddy"],
       "groupName": "caddy"
+    },
+    {
+      "description": "Hold each new aqua: tool version for 3 days. The aqua: pins (trivy, kind, kubectl, gitleaks, act, hadolint, container-structure-test, yq) resolve via the github-tags datasource, and mise's aqua: backend installs from the GitHub Release — which upstreams publish AFTER the git tag. A 3-day buffer lets the Release artifact publish before the PR opens, preventing the tag-before-publish 404 in `mise install`. The major-only buffer does NOT cover aqua minor/patch bumps (e.g. trivy 0.71.0->0.71.1).",
+      "matchManagers": ["mise"],
+      "matchDatasources": ["github-tags"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Throttle the local Renovate CLI pin (RENOVATE_VERSION in the Makefile, custom.regex manager / npm datasource). Renovate publishes several times a day; the manager-scoped npm.minimumReleaseAge does not apply to a custom.regex pin, so a 7-day buffer keeps this dev-only tool roughly weekly instead of opening a near-daily self-bump PR.",
+      "matchDepNames": ["renovate"],
+      "minimumReleaseAge": "7 days"
     }
   ]
 }

--- a/src/service/ether/__tests__/ether.integration.test.ts
+++ b/src/service/ether/__tests__/ether.integration.test.ts
@@ -72,6 +72,16 @@ describe('ether service (negative paths against real RPC)', () => {
     )
   })
 
+  it('getETHBalance (service entry) rejects for a malformed address before any RPC roundtrip', async () => {
+    // Exercises the REAL public service wrapper — not a hand-built client.
+    // getETHBalance calls getAddress() first, so a malformed input rejects at the
+    // service boundary, proving error propagation through the exported API (the
+    // unit suite only covers this path with a mocked client).
+    await expect(getETHBalance('not-an-address')).rejects.toThrow(
+      /is invalid|invalid|not a valid/i,
+    )
+  })
+
   it('rejects with a network error when the configured RPC URL is unreachable', async () => {
     const badClient = createPublicClient({
       chain: mainnet,


### PR DESCRIPTION
## Summary

A `/project-review` + `/test-coverage-analysis` + `/renovate` sweep, plus two CI optimizations requested mid-review (tag-only image build; e2e layer cache).

### Foundation
- **Makefile** — `npm:renovate` moved out of `.mise.toml` to a lazy `RENOVATE_VERSION` pin (no more ~600-pkg reinstall on `make deps`); `cleanup-runs` rewritten to keep newest-5 **per workflow** + exclude open-PR head SHAs (the old global keep-5 could deregister low-frequency workflows and delete idle-PR runs); `container-structure-test` split so CI reuses the scan image; `_require-docker` guards; `DOCKER_BUILD_CACHE` var.
- **renovate.json** — aqua `github-tags` `minimumReleaseAge` (tag-before-Release-publish 404 guard for trivy/kind/etc.); 7-day throttle on the renovate self-bump.
- **ci.yml** — **`docker` + `dast` jobs gated to tag pushes only** (build/scan/SBOM/publish/ZAP at release, not every commit); **`e2e` prod-image build now uses the gha layer cache**; trivy-action repinned to its commit SHA (was a tag-object SHA); `container-structure-test` runs via the make target; docs-gated `mermaid-lint` job; **SBOM upload ACT-guarded** (was failing `make ci-run` at a post-validation step); `persist-credentials: false` on the docker checkout; `specs/`+`benchmarks/` added to the changes filter.
- **cleanup-runs.yml** — `pull-requests: read` for the open-PR exclusion.

### Test coverage
- **e2e-test.sh** — security headers asserted on `/assets/*` + `/internal/*` (handler scope-shadow guard); `/config.js` Content-Type; documented the `/publicnode` override coupling.
- **account-form.spec.ts** — assert the rendered ETH+DAI **balance value** (not just the block); `expect.poll` navigation-detach safety; **`@axe-core/playwright` a11y scan** (verified green against a dev server).
- **ether.integration.test.ts** — service-entry error-propagation test.

### Docs
README Contributing/License; tag-only docker/dast + "Release image hardening"; corrected the Renovate automerge description (`platformAutomerge: false` → PR automerge on green `ci-pass`); CLAUDE.md CI DAG / Tool Versions / test pyramid synced; 3 architecture diagrams verified accurate (no changes needed).

## Verification
- `make static-check`, `make test` (36/36), `make integration-test` (6/6 w/ RPC), `make build`, `make mermaid-lint`, `make renovate-validate`, `actionlint`, and **`make ci-run` (exit 0)** all green locally.
- The tag-only docker/dast paths and the e2e gha cache are exercised on real GHA (act skips those jobs) — this PR's `e2e` run + the next `v*` tag are their first live exercise.

## Test plan
- [ ] CI `ci-pass` green on this PR (e2e exercises the new assertions + gha cache; docker/dast correctly skip on the non-tag push)
- [ ] On the next release tag: docker + dast run; image builds, scans, publishes, signs
