### PR TITLE
fix(makefile): pre-clean root-owned zap-output before dast-scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,7 @@ docker-smoke-test: image-build-prod
 
 #dast-scan: @ Run OWASP ZAP baseline against an already-running smoke container on :8080 (CI gate)
 dast-scan: _require-docker
+	@rm -rf zap-output 2>/dev/null || docker run --rm --user 0 -v "$(PWD):/work" -w /work --entrypoint rm ghcr.io/zaproxy/zaproxy:$(ZAP_VERSION) -rf zap-output
 	@mkdir -p zap-output && chmod 777 zap-output
 	@docker run --rm --network host \
 		-v "$(PWD)/zap-output:/zap/wrk:rw" \


### PR DESCRIPTION
## Problem

`make dast-scan` bind-mounts `zap-output/` into the ZAP container with **no `--user`**, so ZAP (the `zaproxy` image) writes its report files as **root**. On the *next* run, the root-owned output makes `@mkdir -p zap-output && chmod 777 zap-output` fail with `chmod: Operation not permitted`, and `make clean`'s `rm -rf zap-output/` can no longer remove it. This is the root-owned-bind-mount-output footgun (Safety Check #17 in the `/makefile` skill).

## Fix

Insert a root-capable pre-clean immediately before the mkdir/chmod line in `dast-scan`:

```make
@rm -rf zap-output 2>/dev/null || docker run --rm --user 0 -v "$(PWD):/work" -w /work --entrypoint rm ghcr.io/zaproxy/zaproxy:$(ZAP_VERSION) -rf zap-output
```

A plain `rm -rf` runs first; when it can't remove root-owned files, it falls back to a `--user 0` zaproxy container `rm` (the image runs non-root uid 1000, so only a root container can delete root-owned output). Matches the repo's existing style (`$(PWD)`, `$(ZAP_VERSION)`, `@`-prefixed tab-indented recipe line).

`dast` delegates to `dast-scan`, so no sibling target needs a separate fix.

## Verification

- `make -n dast-scan` parses cleanly.
- RED→GREEN proven locally: simulated a root-owned `zap-output/` (`docker run --user 0 ... chown -R 0:0 zap-output`) — `chmod 777 zap-output` failed with `Operation not permitted` (the bug); the new pre-clean line then removed it (exit 0, dir gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
