### PR TITLE
ci: gate e2e and the CVE scans to tag pushes only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,38 @@ jobs:
       - name: Static check
         run: make static-check
 
+  # CVE / vulnerability gates, deliberately TAG-PUSH ONLY (same gating as docker
+  # and dast). vulncheck (pnpm audit), trivy-fs and trivy-config all depend on an
+  # EXTERNAL, drifting advisory feed, so a freshly-disclosed CVE reddens them with
+  # no diff in the repo. On 2026-07-24 exactly that blocked `main` AND all 8 open
+  # PRs for five days over a single react-router advisory. Concentrating them at
+  # the release keeps routine dependency bumps cheap.
+  #
+  # TRADE-OFF: a CVE disclosed between releases is invisible until a tag is cut,
+  # and the tag is what goes red. `make security-check` runs it on demand.
+  security:
+    needs: [changes]
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up mise
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          install: true
+          cache: true
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Security check (CVE + IaC scans)
+        run: make security-check
+
   test:
     needs: [changes, static-check]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' }}
@@ -147,8 +179,12 @@ jobs:
   e2e:
     # KinD-in-Docker inside act doesn't behave reliably; the `make ci-run` target
     # passes `--var ACT=true` to act so this guard skips the job locally.
+    #
+    # TAG-PUSH ONLY, matching docker + dast. Deploy/routing/browser regressions are
+    # therefore NOT caught between releases — the tag is what goes red. Run
+    # `make e2e` and `make e2e-browser` locally before cutting one.
     needs: [changes, build, test]
-    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' && vars.ACT != 'true' }}
+    if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' && vars.ACT != 'true' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Reuse cached prod-image layers across runs (and across make e2e +
@@ -244,7 +280,10 @@ jobs:
     # NOTE: the Dockerfile is still exercised on every push by the `e2e` job
     # (KinD deploy builds the prod image), so a broken Dockerfile is still caught
     # pre-tag there — but the image SCAN / structure-test / SBOM only run on tags.
-    needs: [changes, static-check, build, test]
+    # `security` is a prerequisite so a release can never PUBLISH an image while the
+    # repo's CVE gate is red — the scans moved to tag time, so this is the run that
+    # has to honour them.
+    needs: [changes, static-check, security, build, test]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -512,7 +551,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, mermaid-lint, static-check, build, test, integration-test, e2e, dast, docker]
+    needs: [changes, mermaid-lint, static-check, security, build, test, integration-test, e2e, dast, docker]
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,9 @@ make secrets        # gitleaks over git history
 make mermaid-lint   # validate ```mermaid blocks via minlag/mermaid-cli
 make diagrams       # render docs/diagrams/*.puml C4 sources to PNG via pinned plantuml/plantuml
 make diagrams-check # drift gate: re-render + git diff (fails if committed PNGs are stale vs .puml)
-make static-check   # composite gate: check-node-alignment + lint + vulncheck + trivy-fs + trivy-config + secrets + mermaid-lint + diagrams-check + deps-prune-check
-make check          # static-check + test + build (full local pipeline)
+make static-check   # every-push gate: check-node-alignment + lint + secrets + mermaid-lint + diagrams-check + deps-prune-check
+make security-check # TAG-ONLY in CI: vulncheck + trivy-fs + trivy-config (external advisory feeds)
+make check          # static-check + security-check + test + build (full local pipeline)
 make ci             # CI pipeline: install + static-check + test + integration-test + build
 make ci-run         # run the GitHub Actions workflow locally via act
 make upgrade        # pnpm upgrade
@@ -62,6 +63,7 @@ Four-layer test pyramid. Each layer has its own Makefile target, vitest/Playwrig
 Notes:
 - `make test` and `make integration-test` are independent — the `test` job runs unit + component (no network), `integration-test` job runs the real-RPC suite (needs outbound HTTPS).
 - `e2e` and `dast` are gated `if: vars.ACT != 'true'` in CI because KinD-in-Docker inside act isn't reliable. Run them locally.
+- Since 2026-07-29 `e2e` is additionally **tag-push only**, matching `security`/`dast`/`docker`. Ordinary commits and PRs run only `changes` → `static-check` → (`test`, `integration-test`, `build`) → `ci-pass`. **Deploy, routing, Caddy and browser regressions are therefore NOT caught between releases** — run `make e2e` + `make e2e-browser` locally before cutting a tag. (This is the class that bit on 2026-07-29: a Playwright version-drift bug sat unnoticed for days precisely because `e2e` was not running.)
 - The CI `e2e` job runs both `make e2e` (curl) AND `make e2e-browser` (Playwright Chromium against the deployed SPA) — Playwright is the only layer that catches CSP violations and runtime SPA bugs.
 - The ether unit tests mock viem's `createPublicClient`; component tests mock the `@/service/ether` module entirely.
 
@@ -102,9 +104,10 @@ Vite (oxc minifier, not terser). Console and debugger statements are stripped in
 
 ## CI/CD
 
-- **ci.yml** job DAG: `changes` → `static-check` → (`test`, `integration-test`, `build` parallel) → (`e2e`, `dast`, `docker` parallel) → `ci-pass` (aggregator). A lightweight `mermaid-lint` job also runs off `changes` for **docs-only** changes — README mermaid blocks are docs-excluded from `code`, so `static-check`'s mermaid-lint never sees them; on code changes `static-check` covers mermaid instead, so the job is gated `docs == 'true' && code != 'true'`.
+- **ci.yml** job DAG — **ordinary push/PR:** `changes` → `static-check` → (`test`, `integration-test`, `build` parallel) → `ci-pass` (aggregator). **Tag push additionally:** `security` (off `changes`) plus `e2e`, `dast`, `docker` — the four release-only jobs; `docker` `needs:` `security` so a red CVE gate blocks the publish. A lightweight `mermaid-lint` job also runs off `changes` for **docs-only** changes — README mermaid blocks are docs-excluded from `code`, so `static-check`'s mermaid-lint never sees them; on code changes `static-check` covers mermaid instead, so the job is gated `docs == 'true' && code != 'true'`.
   - `changes`: job-level path filter via `dorny/paths-filter`. Doc-only diffs (`**.md` outside `CLAUDE.md`, `docs/**`, `specs/**`, `benchmarks/**`, `LICENSE`, `**.png`, etc.) set `outputs.code = false` → every heavy job short-circuits via `if: needs.changes.outputs.code == 'true'`. `docs/diagrams/**/*.puml` is re-included as `code` so a diagram-source edit runs `static-check`→`diagrams-check` (else a stale-PNG commit could merge under the docs gate). A second `outputs.docs` (any `**.md`) gates the `mermaid-lint` job. Tag pushes force `code = true` to avoid the empty-diff escape hatch. The workflow itself always runs so `ci-pass` always reports a status — Repository-Rulesets-safe.
-  - `static-check`: composite of check-node-alignment + lint + vulncheck + trivy-fs + trivy-config + secrets + mermaid-lint + diagrams-check + deps-prune-check via `make static-check`.
+  - `static-check`: composite of check-node-alignment + lint + secrets + mermaid-lint + diagrams-check + deps-prune-check via `make static-check`. Deterministic gates only — runs on **every** code push.
+  - `security`: **tag-push only.** `make security-check` = vulncheck (pnpm audit) + trivy-fs + trivy-config. Split out of `static-check` on 2026-07-29 because all three depend on an **external, drifting advisory feed**, so a freshly-disclosed CVE reddens them with no diff in the repo — which is exactly how one react-router advisory blocked `main` **and all 8 open PRs** for five days. `docker` `needs:` it, so a release can never publish an image while the CVE gate is red. **Trade-off:** a CVE disclosed between releases is invisible until a tag is cut, and the tag is what goes red — run `make security-check` (or `make check`) by hand before a release you care about.
   - `integration-test`: real-RPC vitest suite (`make integration-test`).
   - `e2e`: KinD + `cloud-provider-kind` (real LoadBalancer Service IPs on the kind Docker network) + `make e2e` (curl) + `make e2e-browser` (Playwright Chromium). Gated `if: vars.ACT != 'true'`.
   - `dast`: **tag-push only** (mirrors `docker` — `startsWith(github.ref, 'refs/tags/')`). Builds `:scan` image via shared cache, boots it, runs OWASP ZAP baseline (`-I`, FAIL-only blocking) at release. Cached ZAP image (~3.4GB). Also gated `if: vars.ACT != 'true'`. Uploads HTML/JSON/MD report. (Moved off every-push to keep ordinary commits cheap; the image is scanned for CVEs by `docker`'s Trivy gate at the same release.)
@@ -148,7 +151,7 @@ The `docker` job in `ci.yml` builds, scans, and ships images **on tag pushes onl
 - TypeScript: **6.x** with `moduleResolution: "bundler"` (no `baseUrl`, no `esModuleInterop`).
 - Formatting: **prettier** only (no eslint).
 - Parameter externalization: operator-tunable host/port/timeout values live in `.env.example` (committed source of truth; copy to gitignored `.env` to override). Shell scripts source `.env.example` then `.env`; the Makefile mirrors them as `?=` defaults; the SPA reads `VITE_*` at runtime via `/config.js` (Pattern C).
-- Static analysis: **check-node-alignment + prettier + hadolint + Trivy fs + Trivy config + gitleaks + mermaid-lint + diagrams-check**, composed in `make static-check`.
+- Static analysis: **check-node-alignment + prettier + hadolint + gitleaks + mermaid-lint + diagrams-check**, composed in `make static-check` (every push). The CVE/IaC scans — **pnpm audit + Trivy fs + Trivy config** — live in `make security-check`, which CI runs on **tag pushes only**.
 - Commit messages: conventional commits (`feat:`, `fix:`, `chore:`, `ci:`, `refactor:`, `docs:`, `perf:`).
 - Release: `make release` validates semver format (`vN.N.N`), writes `version.txt`, commits and pushes the tag.
 - State management: **Redux Toolkit** with `createSlice` pattern (migrated from Rematch).

--- a/Makefile
+++ b/Makefile
@@ -221,15 +221,33 @@ check-node-alignment:
 	fi; \
 	echo "Node major aligned across all pins ($$mise_major)."
 
-#static-check: @ Composite quality gate: node-alignment + lint + vulncheck + trivy-fs + trivy-config + secrets + mermaid-lint + diagrams-check + deps-prune-check
-static-check: check-node-alignment lint vulncheck trivy-fs trivy-config secrets mermaid-lint diagrams-check deps-prune-check
+#static-check: @ Composite quality gate (every push): node-alignment + lint + secrets + mermaid-lint + diagrams-check + deps-prune-check
+# Deterministic, offline-ish gates only — these run on every code push in CI.
+static-check: check-node-alignment lint secrets mermaid-lint diagrams-check deps-prune-check
+
+#security-check: @ Composite CVE/vuln gate (TAG PUSHES ONLY in CI): vulncheck + trivy-fs + trivy-config
+# Split out of static-check deliberately. All three depend on an EXTERNAL, drifting
+# advisory feed (npm's audit endpoint, Trivy's vuln DB, Trivy's checks bundle), so a
+# freshly-disclosed CVE reddens them with no diff in the repo — which is how a single
+# react-router advisory blocked `main` plus all 8 open PRs for five days on 2026-07-24.
+# Running them at tag time concentrates that cost at the release, where a real
+# decision gets made, instead of taxing every routine dependency bump.
+#
+# TRADE-OFF, stated so nobody rediscovers it the hard way: a CVE disclosed between
+# releases is now invisible until you cut a tag, and the tag is what goes red. Run
+# `make security-check` by hand (or `make check`, which still includes it) before a
+# release you care about. See also the `security` job in .github/workflows/ci.yml.
+security-check: vulncheck trivy-fs trivy-config
 
 #format: @ Run prettier format
 format: install
 	@pnpm prettier
 
-#check: @ Run static-check + test + build (full local pipeline)
-check: static-check test build
+#check: @ Run static-check + security-check + test + build (full local pipeline)
+# Deliberately KEEPS security-check, so `make check` still means what it always did
+# locally. Only CI's ordinary-push path drops the CVE gates; `make ci` mirrors that
+# path exactly, so the two are not in conflict.
+check: static-check security-check test build
 
 #upgrade: @ Upgrade pnpm dependencies
 upgrade: install
@@ -570,7 +588,7 @@ cleanup-images:
 	done
 
 .PHONY: help deps deps-act deps-hadolint deps-k8s deps-trivy deps-secrets deps-playwright clean install build lint vulncheck \
-	trivy-fs trivy-config secrets mermaid-lint diagrams diagrams-check diagrams-clean check-node-alignment static-check format check upgrade \
+	trivy-fs trivy-config secrets mermaid-lint diagrams diagrams-check diagrams-clean check-node-alignment static-check security-check format check upgrade \
 	test test-watch test-coverage integration-test e2e e2e-browser run \
 	image-build image-build-prod image-run image-stop docker-smoke-test container-structure-test container-structure-test-only dast dast-scan _require-docker \
 	ci ci-run ci-run-tag release tag-delete \

--- a/README.md
+++ b/README.md
@@ -236,8 +236,9 @@ Run `make help` to see the full list. Grouped by purpose:
 | `make mermaid-lint` | Validate Mermaid blocks via `minlag/mermaid-cli` |
 | `make deps-prune` | Advisory: list unused npm dependencies |
 | `make deps-prune-check` | CI gate: fail if unused dependencies exist |
-| `make static-check` | Composite: check-node-alignment + lint + vulncheck + trivy-fs + trivy-config + secrets + mermaid-lint + deps-prune-check |
-| `make check` | static-check + test + build (full local pipeline) |
+| `make static-check` | Composite (every push): check-node-alignment + lint + secrets + mermaid-lint + diagrams-check + deps-prune-check |
+| `make security-check` | Composite CVE/IaC gate (**tag pushes only** in CI): vulncheck + trivy-fs + trivy-config |
+| `make check` | static-check + security-check + test + build (full local pipeline) |
 
 ### Docker
 
@@ -295,12 +296,13 @@ GitHub Actions runs on every push to `main`, every tag `v*`, every pull request,
 | Job | Triggers | Steps |
 |-----|----------|-------|
 | **changes** | every event | `dorny/paths-filter` detects whether the diff includes code (anything outside docs/images). Doc-only PRs short-circuit downstream jobs while still reporting `ci-pass` (Rulesets-safe) |
-| **static-check** | after changes (code paths only) | `make install` + `make static-check` (check-node-alignment, lint, vulncheck, trivy-fs, trivy-config, secrets, mermaid-lint, deps-prune-check) |
+| **static-check** | after changes (code paths only) | `make install` + `make static-check` (check-node-alignment, lint, secrets, mermaid-lint, diagrams-check, deps-prune-check) |
+| **security** | **tag pushes only** (after changes) | `make security-check` (vulncheck, trivy-fs, trivy-config). Split out of `static-check` because all three read an external advisory feed, so a newly-disclosed CVE reddens them with no repo diff. `docker` depends on it, so a release cannot publish while it is red. Trade-off: CVEs disclosed between releases surface at tag time — run `make security-check` before cutting one |
 | **mermaid-lint** | docs-only changes (off `changes`) | `make mermaid-lint` validates the README/CLAUDE Mermaid blocks. Code changes run mermaid-lint inside `static-check` instead, so this job fires only when a doc-only edit skips `static-check` |
 | **test** | after static-check | `make test` (unit + component) |
 | **integration-test** | after static-check | `make integration-test` (real-RPC integration suite) |
 | **build** | after static-check | `make build`; uploads `dist/` artifact |
-| **e2e** | after build + test (skipped under act) | KinD + cloud-provider-kind LoadBalancer + curl assertions + Playwright browser e2e — `make e2e` and `make e2e-browser` |
+| **e2e** | **tag pushes only** (after build + test; skipped under act) | KinD + cloud-provider-kind LoadBalancer + curl assertions + Playwright browser e2e — `make e2e` and `make e2e-browser`. Gated to release tags alongside `security`/`dast`/`docker` so ordinary commits stay cheap. Trade-off: deploy/routing/browser regressions surface at tag time — run both targets locally before cutting a release |
 | **dast** | tag pushes only (after build + test; skipped under act) | OWASP ZAP baseline scan against booted container at release; ZAP image cached |
 | **docker** | tag pushes only (after static-check + build + test) | Builds + Trivy image scan + container-structure-test + SPDX SBOM + smoke test + `linux/amd64` build + push to GHCR + cosign keyless signing + SBOM attestation — all gated to release tags (`v*`). No image is built on ordinary commits |
 | **ci-pass** | always (after all above) | Aggregator gate; fails if any upstream job failed or was cancelled |


### PR DESCRIPTION
## What

Ordinary pushes and PRs now run **only**:

```
changes → static-check → (test, integration-test, build) → ci-pass
```

Everything expensive or feed-dependent is concentrated at the release tag:
**`security`, `e2e`, `dast`, `docker`.**

| job | before | after |
|---|---|---|
| `changes`, `mermaid-lint`, `static-check`, `test`, `integration-test`, `build`, `ci-pass` | every push | every push |
| **`security`** *(new)* | — (inside `static-check`) | **tag only** |
| **`e2e`** | every push | **tag only** |
| `dast`, `docker` | tag only | tag only *(unchanged)* |

## CVE scans → new tag-only `security` job

`vulncheck` (pnpm audit), `trivy-fs` and `trivy-config` are split out of the `static-check` composite
into `make security-check`, run by a new `security` job gated on `startsWith(github.ref, 'refs/tags/')`.

The reason these three and not the others: **all three read an external, drifting advisory feed**, so a
newly-disclosed CVE reddens them with **no diff anywhere in the repo**. That is not hypothetical —
it is what this session started with: one react-router advisory
([GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2)) reddened `main` **and all 8
open PRs** for five days, and not one of those PRs had anything to do with it.

`static-check` keeps the deterministic gates — `check-node-alignment`, `lint`, gitleaks `secrets`,
`mermaid-lint`, `diagrams-check`, `deps-prune-check`. Measured at **5s**, versus a composite that
previously pulled Trivy's vuln DB and hit npm's audit endpoint on every single push.

**`docker` now `needs:` `security`**, so a release can never publish an image while the CVE gate is red.
That wiring matters *more* now, not less: the scans only run on the tag, so the tag run is the one that
has to honour them.

## Trade-offs — recorded here rather than discovered later

- **A CVE disclosed between releases is invisible until a tag is cut**, and the tag is what goes red.
  `make security-check` runs it on demand; `make check` still includes it.
- **Deploy, routing, Caddy and browser regressions are no longer caught between releases.** This one has
  a precedent from earlier today: the Playwright version-drift bug fixed in #207 hid for days *precisely
  because* `e2e` was not running (it `needs: static-check`, which was red). Making e2e rarer makes that
  class more likely, not less. **Run `make e2e` + `make e2e-browser` locally before cutting a tag.**

Both trade-offs are written into the Makefile targets, the workflow comments, README and CLAUDE.md — not
just this PR description.

## Local targets

`make check` = `static-check + security-check + test + build`, so it means exactly what it always did.

`make ci` deliberately does **not** gain `security-check`: it mirrors CI's ordinary-push path, and that
mirroring is the property worth keeping.

## Verification

| check | result |
|---|---|
| `make static-check` | **rc=0**, 5s — and grepped clean of all CVE-gate output, confirming the three really moved |
| `make security-check` | **rc=0** — pnpm audit + 4 Trivy report summaries |
| `ci.yml` parses | ✅ via `yaml.safe_load` |
| job DAG | asserted programmatically — `docker` and `ci-pass` both pick up `security` |
| tag-gating | asserted programmatically — `security`/`e2e`/`dast`/`docker` **TAG-ONLY**; `changes`/`mermaid-lint`/`static-check`/`test`/`integration-test`/`build`/`ci-pass` every-push |

Note this PR's own CI will **not** run `e2e` (it is now tag-gated) — that is the change working as
intended. The Playwright fix it would have exercised was already proven green on #207 before this landed.
